### PR TITLE
Add pilosa shard-distribution subcommand

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pilosa/pilosa"
 	"github.com/pilosa/pilosa/server"
@@ -279,6 +280,10 @@ func TestAPI_ShardDistributionByIndex(t *testing.T) {
 	if err := m0.API.Import(ctx, req); err != nil {
 		t.Fatal(err)
 	}
+
+	// TODO: instead of sleeping here, we need to know when the shard-creation
+	// message has propagated.
+	time.Sleep(500 * time.Millisecond)
 
 	tests := []struct {
 		name            string

--- a/client.go
+++ b/client.go
@@ -49,6 +49,7 @@ type InternalClient interface {
 	PostSchema(ctx context.Context, uri *URI, s *Schema, remote bool) error
 	CreateIndex(ctx context.Context, index string, opt IndexOptions) error
 	FragmentNodes(ctx context.Context, index string, shard uint64) ([]*Node, error)
+	ShardDistribution(ctx context.Context, index string, maxShard uint64) ([]Node, [][]uint64, error)
 	Nodes(ctx context.Context) ([]*Node, error)
 	Query(ctx context.Context, index string, queryRequest *QueryRequest) (*QueryResponse, error)
 	QueryNode(ctx context.Context, uri *URI, index string, queryRequest *QueryRequest) (*QueryResponse, error)
@@ -113,6 +114,9 @@ func (n nopInternalClient) CreateIndex(ctx context.Context, index string, opt In
 }
 func (n nopInternalClient) FragmentNodes(ctx context.Context, index string, shard uint64) ([]*Node, error) {
 	return nil, nil
+}
+func (n nopInternalClient) ShardDistribution(ctx context.Context, index string, maxShard uint64) ([]Node, [][]uint64, error) {
+	return nil, nil, nil
 }
 func (n nopInternalClient) Nodes(ctx context.Context) ([]*Node, error) {
 	return nil, nil

--- a/cluster_internal_test.go
+++ b/cluster_internal_test.go
@@ -389,6 +389,47 @@ func TestHasher(t *testing.T) {
 	}
 }
 
+// Ensure shardDistributionByIndex can generate the correct shard distribution lists.
+func TestCluster_ShardDistribution(t *testing.T) {
+	t.Run("Replication1", func(t *testing.T) {
+		c := NewTestCluster(5)
+		c.ReplicaN = 1
+
+		_, shards := c.shardDistributionByIndex("idx", 12)
+
+		exp := [][]uint64{
+			{9, 12},
+			{1, 4, 7, 8, 11},
+			{},
+			{0, 3, 6, 10},
+			{2, 5},
+		}
+
+		if !reflect.DeepEqual(shards, exp) {
+			t.Fatalf("unexpected shard distribution for index: %v", shards)
+		}
+	})
+
+	t.Run("Replication2", func(t *testing.T) {
+		c := NewTestCluster(5)
+		c.ReplicaN = 2
+
+		_, shards := c.shardDistributionByIndex("idx", 12)
+
+		exp := [][]uint64{
+			{2, 5, 9, 12},
+			{1, 4, 7, 8, 9, 11, 12},
+			{1, 4, 7, 8, 11},
+			{0, 3, 6, 10},
+			{0, 2, 3, 5, 6, 10},
+		}
+
+		if !reflect.DeepEqual(shards, exp) {
+			t.Fatalf("unexpected shard distribution for index: %v", shards)
+		}
+	})
+}
+
 // Ensure ContainsShards can find the actual shard list for node and index.
 func TestCluster_ContainsShards(t *testing.T) {
 	c := NewTestCluster(5)
@@ -396,7 +437,7 @@ func TestCluster_ContainsShards(t *testing.T) {
 	shards := c.containsShards("test", roaring.NewBitmap(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c.nodes[2])
 
 	if !reflect.DeepEqual(shards, []uint64{0, 2, 3, 5, 6, 9, 10}) {
-		t.Fatalf("unexpected shars for node's index: %v", shards)
+		t.Fatalf("unexpected shards for node's index: %v", shards)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,6 +75,7 @@ Build Time: ` + pilosa.BuildTime + "\n",
 	rc.AddCommand(newImportCommand(stdin, stdout, stderr))
 	rc.AddCommand(newInspectCommand(stdin, stdout, stderr))
 	rc.AddCommand(newServeCmd(stdin, stdout, stderr))
+	rc.AddCommand(newShardDistributionCommand(stdin, stdout, stderr))
 
 	rc.SetOutput(stderr)
 	return rc

--- a/cmd/shard_distribution.go
+++ b/cmd/shard_distribution.go
@@ -45,7 +45,6 @@ Pilosa cluster.
 	flags.IntVarP(&shardDistributioner.NumNodes, "num-nodes", "n", 1, "Number of nodes in the cluster")
 	flags.IntVarP(&shardDistributioner.MaxShard, "max-shard", "m", 0, "Maximum shard to include (0-indexed)")
 	flags.IntVarP(&shardDistributioner.ReplicaN, "replicas", "r", 1, "Number of replicas to include")
-	flags.StringVarP(&shardDistributioner.Path, "output-file", "o", "", "File to write shard distribution to - default stdout")
 	ctl.SetTLSConfig(flags, &shardDistributioner.TLS.CertificatePath, &shardDistributioner.TLS.CertificateKeyPath, &shardDistributioner.TLS.SkipVerify)
 
 	return shardDistributionCmd

--- a/cmd/shard_distribution.go
+++ b/cmd/shard_distribution.go
@@ -1,0 +1,52 @@
+// Copyright 2017 Pilosa Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pilosa/pilosa/ctl"
+)
+
+var shardDistributioner *ctl.ShardDistributionCommand
+
+func newShardDistributionCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
+	shardDistributioner = ctl.NewShardDistributionCommand(stdin, stdout, stderr)
+	shardDistributionCmd := &cobra.Command{
+		Use:   "shard-distribution",
+		Short: "Shard distribution data from pilosa.",
+		Long: `
+Returns the shard distribution based on the provided arguments, or on a running
+Pilosa cluster.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return shardDistributioner.Run(context.Background())
+		},
+	}
+	flags := shardDistributionCmd.Flags()
+
+	flags.StringVarP(&shardDistributioner.Host, "host", "", "", "host:port of Pilosa")
+	flags.StringVarP(&shardDistributioner.Index, "index", "i", "", "Pilosa index to consider")
+	flags.IntVarP(&shardDistributioner.NumNodes, "num-nodes", "n", 1, "Number of nodes in the cluster")
+	flags.IntVarP(&shardDistributioner.MaxShard, "max-shard", "m", 0, "Maximum shard to include (0-indexed)")
+	flags.IntVarP(&shardDistributioner.ReplicaN, "replicas", "r", 1, "Number of replicas to include")
+	flags.StringVarP(&shardDistributioner.Path, "output-file", "o", "", "File to write shard distribution to - default stdout")
+	ctl.SetTLSConfig(flags, &shardDistributioner.TLS.CertificatePath, &shardDistributioner.TLS.CertificateKeyPath, &shardDistributioner.TLS.SkipVerify)
+
+	return shardDistributionCmd
+}

--- a/ctl/shard_distribution.go
+++ b/ctl/shard_distribution.go
@@ -43,9 +43,6 @@ type ShardDistributionCommand struct {
 	// Replicas to include in shard distribution.
 	ReplicaN int
 
-	// Filename to export to.
-	Path string
-
 	// Standard input/output
 	*pilosa.CmdIO
 
@@ -72,7 +69,7 @@ func (cmd *ShardDistributionCommand) Run(ctx context.Context) error {
 	maxShard := uint64(cmd.MaxShard)
 
 	//nodes := []pilosa.Node{}
-	shards := [][]uint64{}
+	var shards [][]uint64
 
 	// If no host is specified, launch an in-memory cluster.
 	if cmd.Host == "" {

--- a/ctl/shard_distribution.go
+++ b/ctl/shard_distribution.go
@@ -1,0 +1,133 @@
+// Copyright 2017 Pilosa Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+
+	"github.com/pilosa/pilosa"
+	"github.com/pilosa/pilosa/server"
+	"github.com/pkg/errors"
+)
+
+// ShardDistributionCommand represents a command for bulk exporting data from a server.
+type ShardDistributionCommand struct {
+	// Remote host and port.
+	Host string
+
+	// Name of the index & field to export from.
+	Index string
+
+	// Number of nodes in the cluster.
+	NumNodes int
+
+	// Maximum Shard to include.
+	MaxShard int
+
+	// Replicas to include in shard distribution.
+	ReplicaN int
+
+	// Filename to export to.
+	Path string
+
+	// Standard input/output
+	*pilosa.CmdIO
+
+	TLS server.TLSConfig
+}
+
+// NewShardDistributionCommand returns a new instance of ShardDistributionCommand.
+func NewShardDistributionCommand(stdin io.Reader, stdout, stderr io.Writer) *ShardDistributionCommand {
+	return &ShardDistributionCommand{
+		CmdIO: pilosa.NewCmdIO(stdin, stdout, stderr),
+	}
+}
+
+// Run executes the shard location logic.
+func (cmd *ShardDistributionCommand) Run(ctx context.Context) error {
+	logger := log.New(cmd.Stderr, "", log.LstdFlags)
+
+	// Validate arguments.
+	if cmd.Index == "" {
+		return pilosa.ErrIndexRequired
+	}
+
+	numNodes := cmd.NumNodes
+	maxShard := uint64(cmd.MaxShard)
+
+	//nodes := []pilosa.Node{}
+	shards := [][]uint64{}
+
+	// If no host is specified, launch an in-memory cluster.
+	if cmd.Host == "" {
+
+		memCluster := make([]*server.Command, numNodes)
+
+		additionalNodes := make([]string, numNodes-1)
+		for i := range additionalNodes {
+			additionalNodes[i] = fmt.Sprintf("node%d", i+1)
+		}
+
+		for i := range memCluster {
+			memCluster[i] = server.NewCommand(cmd.Stdin, cmd.Stdout, cmd.Stderr)
+			memCluster[i].Config.Bind = ":0"
+			memCluster[i].Config.LogPath = "/dev/null"
+			memCluster[i].Config.Cluster.Disabled = true
+			memCluster[i].Config.Cluster.Coordinator = true
+			memCluster[i].Config.Cluster.ReplicaN = cmd.ReplicaN
+			memCluster[i].Config.Cluster.Hosts = additionalNodes
+
+			if err := memCluster[i].SetupServer(); err != nil {
+				return errors.Wrapf(err, "setting up server %d", i)
+			}
+		}
+
+		m0 := memCluster[0]
+		logger.Printf("in-memory cmd: %v\n", m0.API)
+
+		_, shards = m0.API.ShardDistributionByIndex(ctx, cmd.Index, true, maxShard)
+	} else {
+		// Create a client to the server.
+		client, err := commandClient(cmd)
+		if err != nil {
+			return errors.Wrap(err, "creating client")
+		}
+
+		_, shards, err = client.ShardDistribution(ctx, cmd.Index, maxShard)
+		if err != nil {
+			return errors.Wrap(err, "getting shard distribution")
+		}
+	}
+
+	buf, err := json.Marshal(shards)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.Stdout, string(buf))
+
+	return nil
+}
+
+func (cmd *ShardDistributionCommand) TLSHost() string {
+	return cmd.Host
+}
+
+func (cmd *ShardDistributionCommand) TLSConfiguration() server.TLSConfig {
+	return cmd.TLS
+}

--- a/http/client.go
+++ b/http/client.go
@@ -257,12 +257,12 @@ func (c *InternalClient) ShardDistribution(ctx context.Context, index string, ma
 		return nil, nil, errors.Wrap(err, "decoding")
 	}
 
-	n := make([]pilosa.Node, len(rsp.Standard))
-	s := make([][]uint64, len(rsp.Standard))
+	n := make([]pilosa.Node, len(rsp.Distribution))
+	s := make([][]uint64, len(rsp.Distribution))
 
-	for i := range rsp.Standard {
-		n[i] = rsp.Standard[i].Node
-		s[i] = rsp.Standard[i].Shards
+	for i := range rsp.Distribution {
+		n[i] = rsp.Distribution[i].Node
+		s[i] = rsp.Distribution[i].Shards
 	}
 
 	return n, s, nil

--- a/http/handler.go
+++ b/http/handler.go
@@ -562,7 +562,9 @@ func (h *Handler) handleGetShardsDistribution(w http.ResponseWriter, r *http.Req
 		})
 	}
 
-	if err := json.NewEncoder(w).Encode(ns); err != nil {
+	if err := json.NewEncoder(w).Encode(getShardsDistributionResponse{
+		Distribution: ns,
+	}); err != nil {
 		h.logger.Printf("shards-distribution response error: %s", err)
 	}
 }
@@ -574,7 +576,7 @@ type nodeShards struct {
 }
 
 type getShardsDistributionResponse struct {
-	Standard []nodeShards `json:"standard"`
+	Distribution []nodeShards `json:"distribution"`
 }
 
 // handleGetShardsMax handles GET /internal/shards/max requests.


### PR DESCRIPTION
## Overview

This PR adds a subcommand `shard-distribution` to Pilosa that will return the shard placement based on various cluster parameters (index name, number of nodes, replication, max shard).

If a `--host` is provided, it will base its calculations off of an existing pilosa cluster. If not, it will start an in-memory cluster to determine the shard distribution.

This PR also adds a new API method (and corresponding client methods), so I would like some feedback on the decisions made with those.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Add appropriate changelog label to PR (if applicable).

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Make sure PR is tagged with appropriate changelog label.
