### PR TITLE
Refactor consistent hashing implementation

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -27,18 +27,22 @@ import (
 	"github.com/pilosa/pilosa/test"
 )
 
+const MOD = "mod"
+
 func TestAPI_Import(t *testing.T) {
 	partitionN := 2
 	c := test.MustRunCluster(t, 2,
 		[]server.CommandOption{
 			server.OptCommandServerOptions(
 				pilosa.OptServerNodeID("node0"),
-				pilosa.OptServerShardDistributor(newOffsetModDistributor(partitionN)),
+				pilosa.OptServerShardDistributors(map[string]pilosa.ShardDistributor{MOD: newOffsetModDistributor(partitionN)}),
+				pilosa.OptServerDefaultShardDistributor(MOD),
 			)},
 		[]server.CommandOption{
 			server.OptCommandServerOptions(
 				pilosa.OptServerNodeID("node1"),
-				pilosa.OptServerShardDistributor(newOffsetModDistributor(partitionN)),
+				pilosa.OptServerShardDistributors(map[string]pilosa.ShardDistributor{MOD: newOffsetModDistributor(partitionN)}),
+				pilosa.OptServerDefaultShardDistributor(MOD),
 			)},
 	)
 	defer c.Close()
@@ -179,12 +183,14 @@ func TestAPI_ImportValue(t *testing.T) {
 		[]server.CommandOption{
 			server.OptCommandServerOptions(
 				pilosa.OptServerNodeID("node0"),
-				pilosa.OptServerShardDistributor(newOffsetModDistributor(partitionN)),
+				pilosa.OptServerShardDistributors(map[string]pilosa.ShardDistributor{MOD: newOffsetModDistributor(partitionN)}),
+				pilosa.OptServerDefaultShardDistributor(MOD),
 			)},
 		[]server.CommandOption{
 			server.OptCommandServerOptions(
 				pilosa.OptServerNodeID("node1"),
-				pilosa.OptServerShardDistributor(newOffsetModDistributor(partitionN)),
+				pilosa.OptServerShardDistributors(map[string]pilosa.ShardDistributor{MOD: newOffsetModDistributor(partitionN)}),
+				pilosa.OptServerDefaultShardDistributor(MOD),
 			)},
 	)
 	defer c.Close()

--- a/api_test.go
+++ b/api_test.go
@@ -263,3 +263,9 @@ func (d *offsetModDistributor) NodeOwners(nodeIDs []string, replicaN int, index 
 	}
 	return owners
 }
+
+// AddNode is a nop and only exists to satisfy the `ShardDistributor` interface.
+func (d *offsetModDistributor) AddNode(nodeID string) error { return nil }
+
+// RemoveNode is a nop and only exists to satisfy the `ShardDistributor` interface.
+func (d *offsetModDistributor) RemoveNode(nodeID string) error { return nil }

--- a/cluster.go
+++ b/cluster.go
@@ -232,7 +232,7 @@ type cluster struct { // nolint: maligned
 // newCluster returns a new instance of Cluster with defaults.
 func newCluster() *cluster {
 	return &cluster{
-		ShardDistributor: &jumpDistributor{partitionN: defaultPartitionN},
+		ShardDistributor: newJumpDistributor(defaultPartitionN),
 		partitionN:       defaultPartitionN,
 		ReplicaN:         1,
 
@@ -891,6 +891,12 @@ type ShardDistributor interface {
 
 type jumpDistributor struct {
 	partitionN int
+}
+
+func newJumpDistributor(partitionN int) *jumpDistributor {
+	return &jumpDistributor{
+		partitionN: partitionN,
+	}
 }
 
 // Hash returns the integer hash for the given key.

--- a/cluster.go
+++ b/cluster.go
@@ -183,9 +183,6 @@ type cluster struct { // nolint: maligned
 	// Shard distributing algorithm to distribute shards to nodes.
 	ShardDistributor ShardDistributor
 
-	// The number of partitions in the cluster.
-	partitionN int
-
 	// The number of replicas a partition has.
 	ReplicaN int
 
@@ -233,7 +230,6 @@ type cluster struct { // nolint: maligned
 func newCluster() *cluster {
 	return &cluster{
 		ShardDistributor: newJumpDistributor(defaultPartitionN),
-		partitionN:       defaultPartitionN,
 		ReplicaN:         1,
 
 		joiningLeavingNodes: make(chan nodeAction, 10), // buffered channel
@@ -792,7 +788,6 @@ func (c *cluster) fragSources(to *cluster, idx *Index) (map[string][]*ResizeSour
 		srcCluster = newCluster()
 		srcCluster.nodes = Nodes(c.nodes).Clone()
 		srcCluster.ShardDistributor = c.ShardDistributor
-		srcCluster.partitionN = c.partitionN
 		srcCluster.ReplicaN = 1
 	}
 
@@ -1243,7 +1238,6 @@ func (c *cluster) unprotectedGenerateResizeJobByAction(nodeAction nodeAction) (*
 	toCluster := newCluster()
 	toCluster.nodes = Nodes(c.nodes).Clone()
 	toCluster.ShardDistributor = c.ShardDistributor
-	toCluster.partitionN = c.partitionN
 	toCluster.ReplicaN = c.ReplicaN
 	if nodeAction.action == resizeJobActionRemove {
 		toCluster.removeNodeBasicSorted(nodeAction.node.ID)

--- a/cluster.go
+++ b/cluster.go
@@ -855,7 +855,7 @@ func (c *cluster) shardNodes(index string, shard uint64) []*Node {
 	nodeIDs := c.ShardDistributor.NodeOwners(c.nodeIDs(), c.ReplicaN, index, shard)
 	nodes := make([]*Node, 0)
 	for _, ID := range nodeIDs {
-		node := c.nodeByID(ID)
+		node := c.unprotectedNodeByID(ID)
 		nodes = append(nodes, node)
 	}
 	return nodes

--- a/cluster_internal_test.go
+++ b/cluster_internal_test.go
@@ -328,8 +328,9 @@ func TestCluster_Owners(t *testing.T) {
 			{URI: NewTestURIFromHostPort("serverB", 1000)},
 			{URI: NewTestURIFromHostPort("serverC", 1000)},
 		},
-		ShardDistributor: NewTestModDistributor(3),
-		ReplicaN:         2,
+		shardDistributors:       map[string]ShardDistributor{MOD: NewTestModDistributor(3)},
+		defaultShardDistributor: MOD,
+		ReplicaN:                2,
 	}
 
 	// Verify nodes are distributed.
@@ -367,7 +368,7 @@ func TestHasher(t *testing.T) {
 // Ensure ContainsShards can find the actual shard list for node and index.
 func TestCluster_ContainsShards(t *testing.T) {
 	c := NewTestCluster(5)
-	c.ShardDistributor = NewTestModDistributor(5)
+	c.shardDistributors[MOD] = NewTestModDistributor(5)
 	c.ReplicaN = 3
 	shards := c.containsShards("test", roaring.NewBitmap(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c.nodes[2])
 
@@ -379,7 +380,8 @@ func TestCluster_ContainsShards(t *testing.T) {
 // Ensure Jump distributor distributes shards the same way as previous implementation.
 func TestCluster_JumpDistributor(t *testing.T) {
 	c := NewTestCluster(5)
-	c.ShardDistributor = newJumpDistributor(defaultPartitionN)
+	c.shardDistributors[JUMP] = newJumpDistributor(defaultPartitionN)
+	c.defaultShardDistributor = JUMP
 	c.ReplicaN = 3
 
 	tests := []struct {

--- a/cluster_internal_test.go
+++ b/cluster_internal_test.go
@@ -379,7 +379,7 @@ func TestCluster_ContainsShards(t *testing.T) {
 // Ensure Jump distributor distributes shards the same way as previous implementation.
 func TestCluster_JumpDistributor(t *testing.T) {
 	c := NewTestCluster(5)
-	c.ShardDistributor = &jumpDistributor{partitionN: defaultPartitionN}
+	c.ShardDistributor = newJumpDistributor(defaultPartitionN)
 	c.ReplicaN = 3
 
 	tests := []struct {

--- a/cluster_internal_test.go
+++ b/cluster_internal_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -28,7 +27,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"testing/quick"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -330,41 +328,18 @@ func TestCluster_Owners(t *testing.T) {
 			{URI: NewTestURIFromHostPort("serverB", 1000)},
 			{URI: NewTestURIFromHostPort("serverC", 1000)},
 		},
-		Hasher:   NewTestModHasher(),
-		ReplicaN: 2,
+		ShardDistributor: NewTestModDistributor(3),
+		ReplicaN:         2,
 	}
 
 	// Verify nodes are distributed.
-	if a := c.partitionNodes(0); !reflect.DeepEqual(a, []*Node{c.nodes[0], c.nodes[1]}) {
+	if a := c.shardNodes("index", 0); !reflect.DeepEqual(a, []*Node{c.nodes[0], c.nodes[1]}) {
 		t.Fatalf("unexpected owners: %s", spew.Sdump(a))
 	}
 
 	// Verify nodes go around the ring.
-	if a := c.partitionNodes(2); !reflect.DeepEqual(a, []*Node{c.nodes[2], c.nodes[0]}) {
+	if a := c.shardNodes("index", 2); !reflect.DeepEqual(a, []*Node{c.nodes[2], c.nodes[0]}) {
 		t.Fatalf("unexpected owners: %s", spew.Sdump(a))
-	}
-}
-
-// Ensure the partitioner can assign a fragment to a partition.
-func TestCluster_Partition(t *testing.T) {
-	if err := quick.Check(func(index string, shard uint64, partitionN int) bool {
-		c := newCluster()
-		c.partitionN = partitionN
-
-		partitionID := c.partition(index, shard)
-		if partitionID < 0 || partitionID >= partitionN {
-			t.Errorf("partition out of range: shard=%d, p=%d, n=%d", shard, partitionID, partitionN)
-		}
-
-		return true
-	}, &quick.Config{
-		Values: func(values []reflect.Value, rand *rand.Rand) {
-			values[0], _ = quick.Value(reflect.TypeOf(""), rand)
-			values[1] = reflect.ValueOf(uint64(rand.Uint32()))
-			values[2] = reflect.ValueOf(rand.Intn(1000) + 1)
-		},
-	}); err != nil {
-		t.Fatal(err)
 	}
 }
 
@@ -381,8 +356,8 @@ func TestHasher(t *testing.T) {
 		{0x0ddc0ffeebadf00d, []int{0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 15, 15, 15, 15}},
 	} {
 		for i, v := range tt.bucket {
-			hasher := &jmphasher{}
-			if got := hasher.Hash(tt.key, i+1); got != v {
+			distributor := &jumpDistributor{}
+			if got := distributor.Hash(tt.key, i+1); got != v {
 				t.Errorf("hash(%v,%v)=%v, want %v", tt.key, i+1, got, v)
 			}
 		}
@@ -392,11 +367,12 @@ func TestHasher(t *testing.T) {
 // Ensure ContainsShards can find the actual shard list for node and index.
 func TestCluster_ContainsShards(t *testing.T) {
 	c := NewTestCluster(5)
+	c.ShardDistributor = NewTestModDistributor(5)
 	c.ReplicaN = 3
 	shards := c.containsShards("test", roaring.NewBitmap(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c.nodes[2])
 
-	if !reflect.DeepEqual(shards, []uint64{0, 2, 3, 5, 6, 9, 10}) {
-		t.Fatalf("unexpected shars for node's index: %v", shards)
+	if !reflect.DeepEqual(shards, []uint64{0, 1, 2, 5, 6, 7, 10}) {
+		t.Fatalf("unexpected shards for node's index: %v", shards)
 	}
 }
 

--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -596,8 +596,9 @@ func encodeCreateIndexMessage(m *pilosa.CreateIndexMessage) *internal.CreateInde
 
 func encodeIndexMeta(m *pilosa.IndexOptions) *internal.IndexMeta {
 	return &internal.IndexMeta{
-		Keys:           m.Keys,
-		TrackExistence: m.TrackExistence,
+		Keys:             m.Keys,
+		TrackExistence:   m.TrackExistence,
+		ShardDistributor: m.ShardDistributor,
 	}
 }
 
@@ -855,6 +856,7 @@ func decodeCreateIndexMessage(pb *internal.CreateIndexMessage, m *pilosa.CreateI
 func decodeIndexMeta(pb *internal.IndexMeta, m *pilosa.IndexOptions) {
 	m.Keys = pb.Keys
 	m.TrackExistence = pb.TrackExistence
+	m.ShardDistributor = pb.ShardDistributor
 }
 
 func decodeDeleteIndexMessage(pb *internal.DeleteIndexMessage, m *pilosa.DeleteIndexMessage) {

--- a/executor_test.go
+++ b/executor_test.go
@@ -2338,9 +2338,17 @@ func TestExecutor_Execute_Remote_Row(t *testing.T) {
 	partitionN := 2
 	c := test.MustRunCluster(t, 2,
 		[]server.CommandOption{
-			server.OptCommandServerOptions(pilosa.OptServerNodeID("node0"), pilosa.OptServerShardDistributor(test.NewModDistributor(partitionN)))},
+			server.OptCommandServerOptions(
+				pilosa.OptServerNodeID("node0"),
+				pilosa.OptServerShardDistributors(map[string]pilosa.ShardDistributor{MOD: test.NewModDistributor(partitionN)}),
+				pilosa.OptServerDefaultShardDistributor(MOD),
+			)},
 		[]server.CommandOption{
-			server.OptCommandServerOptions(pilosa.OptServerNodeID("node1"), pilosa.OptServerShardDistributor(test.NewModDistributor(partitionN)))},
+			server.OptCommandServerOptions(
+				pilosa.OptServerNodeID("node1"),
+				pilosa.OptServerShardDistributors(map[string]pilosa.ShardDistributor{MOD: test.NewModDistributor(partitionN)}),
+				pilosa.OptServerDefaultShardDistributor(MOD),
+			)},
 	)
 	defer c.Close()
 	hldr0 := test.Holder{Holder: c[0].Server.Holder()}

--- a/executor_test.go
+++ b/executor_test.go
@@ -2335,11 +2335,12 @@ func TestExecutor_Execute_Range_BSIGroup_Deprecated(t *testing.T) {
 
 // Ensure a remote query can return a row.
 func TestExecutor_Execute_Remote_Row(t *testing.T) {
+	partitionN := 2
 	c := test.MustRunCluster(t, 2,
 		[]server.CommandOption{
-			server.OptCommandServerOptions(pilosa.OptServerNodeID("node0"), pilosa.OptServerClusterHasher(&test.ModHasher{}))},
+			server.OptCommandServerOptions(pilosa.OptServerNodeID("node0"), pilosa.OptServerShardDistributor(test.NewModDistributor(partitionN)))},
 		[]server.CommandOption{
-			server.OptCommandServerOptions(pilosa.OptServerNodeID("node1"), pilosa.OptServerClusterHasher(&test.ModHasher{}))},
+			server.OptCommandServerOptions(pilosa.OptServerNodeID("node1"), pilosa.OptServerShardDistributor(test.NewModDistributor(partitionN)))},
 	)
 	defer c.Close()
 	hldr0 := test.Holder{Holder: c[0].Server.Holder()}

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -35,6 +35,8 @@ import (
 
 // Test distributed TopN Row count across 3 nodes.
 func TestClient_MultiNode(t *testing.T) {
+	// For testing with modhasher, we set the number
+	// of partitions to the number of nodes.
 	partitionN := 3
 	c := test.MustRunCluster(t, 3,
 		[]server.CommandOption{
@@ -52,27 +54,7 @@ func TestClient_MultiNode(t *testing.T) {
 	}
 
 	// Create a dispersed set of bitmaps across 3 nodes such that each individual node and shard width increment would reveal a different TopN.
-	shardNums := []uint64{1, 2, 6}
-
-	// This was generated with: `owns := s[i].Handler.Handler.API.Cluster.OwnsShards("i", 20, s[i].HostURI())`
-	owns := [][]uint64{
-		{1, 3, 4, 8, 10, 13, 17, 19},
-		{2, 5, 7, 11, 12, 14, 18},
-		{0, 6, 9, 15, 16, 20},
-	}
-
-	for i, num := range shardNums {
-		ownsNum := false
-		for _, ownNum := range owns[i] {
-			if ownNum == num {
-				ownsNum = true
-				break
-			}
-		}
-		if !ownsNum {
-			t.Fatalf("Trying to use shard %d on host %s, but it doesn't own that shard. It owns %v", num, c[i].URL(), owns)
-		}
-	}
+	shardNums := []uint64{0, 1, 2}
 
 	baseBit0 := pilosa.ShardWidth * shardNums[0]
 	baseBit1 := pilosa.ShardWidth * shardNums[1]

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -35,13 +35,14 @@ import (
 
 // Test distributed TopN Row count across 3 nodes.
 func TestClient_MultiNode(t *testing.T) {
+	partitionN := 3
 	c := test.MustRunCluster(t, 3,
 		[]server.CommandOption{
-			server.OptCommandServerOptions(pilosa.OptServerNodeID("node0"), pilosa.OptServerClusterHasher(&test.ModHasher{}))},
+			server.OptCommandServerOptions(pilosa.OptServerNodeID("node0"), pilosa.OptServerShardDistributor(test.NewModDistributor(partitionN)))},
 		[]server.CommandOption{
-			server.OptCommandServerOptions(pilosa.OptServerNodeID("node1"), pilosa.OptServerClusterHasher(&test.ModHasher{}))},
+			server.OptCommandServerOptions(pilosa.OptServerNodeID("node1"), pilosa.OptServerShardDistributor(test.NewModDistributor(partitionN)))},
 		[]server.CommandOption{
-			server.OptCommandServerOptions(pilosa.OptServerNodeID("node2"), pilosa.OptServerClusterHasher(&test.ModHasher{}))},
+			server.OptCommandServerOptions(pilosa.OptServerNodeID("node2"), pilosa.OptServerShardDistributor(test.NewModDistributor(partitionN)))},
 	)
 	defer c.Close()
 

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/pilosa/pilosa/test"
 )
 
+const MOD = "mod"
+
 // Test distributed TopN Row count across 3 nodes.
 func TestClient_MultiNode(t *testing.T) {
 	// For testing with modhasher, we set the number
@@ -40,11 +42,23 @@ func TestClient_MultiNode(t *testing.T) {
 	partitionN := 3
 	c := test.MustRunCluster(t, 3,
 		[]server.CommandOption{
-			server.OptCommandServerOptions(pilosa.OptServerNodeID("node0"), pilosa.OptServerShardDistributor(test.NewModDistributor(partitionN)))},
+			server.OptCommandServerOptions(
+				pilosa.OptServerNodeID("node0"),
+				pilosa.OptServerShardDistributors(map[string]pilosa.ShardDistributor{MOD: test.NewModDistributor(partitionN)}),
+				pilosa.OptServerDefaultShardDistributor(MOD),
+			)},
 		[]server.CommandOption{
-			server.OptCommandServerOptions(pilosa.OptServerNodeID("node1"), pilosa.OptServerShardDistributor(test.NewModDistributor(partitionN)))},
+			server.OptCommandServerOptions(
+				pilosa.OptServerNodeID("node1"),
+				pilosa.OptServerShardDistributors(map[string]pilosa.ShardDistributor{MOD: test.NewModDistributor(partitionN)}),
+				pilosa.OptServerDefaultShardDistributor(MOD),
+			)},
 		[]server.CommandOption{
-			server.OptCommandServerOptions(pilosa.OptServerNodeID("node2"), pilosa.OptServerShardDistributor(test.NewModDistributor(partitionN)))},
+			server.OptCommandServerOptions(
+				pilosa.OptServerNodeID("node2"),
+				pilosa.OptServerShardDistributors(map[string]pilosa.ShardDistributor{MOD: test.NewModDistributor(partitionN)}),
+				pilosa.OptServerDefaultShardDistributor(MOD),
+			)},
 	)
 	defer c.Close()
 

--- a/http/handler.go
+++ b/http/handler.go
@@ -603,8 +603,9 @@ func (p *postIndexRequest) UnmarshalJSON(b []byte) error {
 	// Unmarshal expected values.
 	_p := _postIndexRequest{
 		Options: pilosa.IndexOptions{
-			Keys:           false,
-			TrackExistence: true,
+			Keys:             false,
+			TrackExistence:   true,
+			ShardDistributor: pilosa.JUMP,
 		},
 	}
 	if err := json.Unmarshal(b, &_p); err != nil {
@@ -684,8 +685,9 @@ func (h *Handler) handlePostIndex(w http.ResponseWriter, r *http.Request) {
 	// Decode request.
 	req := postIndexRequest{
 		Options: pilosa.IndexOptions{
-			Keys:           false,
-			TrackExistence: true,
+			Keys:             false,
+			TrackExistence:   true,
+			ShardDistributor: pilosa.JUMP,
 		},
 	}
 	err := json.NewDecoder(r.Body).Decode(&req)

--- a/http/handler_internal_test.go
+++ b/http/handler_internal_test.go
@@ -31,9 +31,10 @@ func TestPostIndexRequestUnmarshalJSON(t *testing.T) {
 		expected postIndexRequest
 		err      string
 	}{
-		{json: `{"options": {}}`, expected: postIndexRequest{Options: pilosa.IndexOptions{TrackExistence: true}}},
-		{json: `{"options": {"trackExistence": false}}`, expected: postIndexRequest{Options: pilosa.IndexOptions{TrackExistence: false}}},
-		{json: `{"options": {"keys": true}}`, expected: postIndexRequest{Options: pilosa.IndexOptions{Keys: true, TrackExistence: true}}},
+		{json: `{"options": {}}`, expected: postIndexRequest{Options: pilosa.IndexOptions{TrackExistence: true, ShardDistributor: "jump"}}},
+		{json: `{"options": {"trackExistence": false}}`, expected: postIndexRequest{Options: pilosa.IndexOptions{TrackExistence: false, ShardDistributor: "jump"}}},
+		{json: `{"options": {"keys": true}}`, expected: postIndexRequest{Options: pilosa.IndexOptions{Keys: true, TrackExistence: true, ShardDistributor: "jump"}}},
+		{json: `{"options": {"shardDistributor": "consistent"}}`, expected: postIndexRequest{Options: pilosa.IndexOptions{TrackExistence: true, ShardDistributor: "consistent"}}},
 		{json: `{"options": 4}`, err: "options is not map[string]interface{}"},
 		{json: `{"option": {}}`, err: "unknown key: option:map[]"},
 		{json: `{"options": {"badKey": "test"}}`, err: "unknown key: badKey:test"},

--- a/internal/private.proto
+++ b/internal/private.proto
@@ -5,6 +5,7 @@ package internal;
 message IndexMeta {
 	bool Keys = 3;
 	bool TrackExistence = 4;
+	string ShardDistributor = 5;
 }
 
 message FieldOptions {

--- a/server.go
+++ b/server.go
@@ -276,12 +276,12 @@ func OptServerNodeID(nodeID string) ServerOption {
 	}
 }
 
-// OptServerClusterHasher is a functional option on Server
-// used to specify the consistent hash algorithm for data
-// location within the cluster.
-func OptServerClusterHasher(h Hasher) ServerOption {
+// OptServerShardDistributor is a functional option on Server
+// used to specify the shard distributing algorithm for
+// distributing shards to nodes in the cluster.
+func OptServerShardDistributor(d ShardDistributor) ServerOption {
 	return func(s *Server) error {
-		s.cluster.Hasher = h
+		s.cluster.ShardDistributor = d
 		return nil
 	}
 }

--- a/server.go
+++ b/server.go
@@ -282,6 +282,12 @@ func OptServerNodeID(nodeID string) ServerOption {
 func OptServerShardDistributor(d ShardDistributor) ServerOption {
 	return func(s *Server) error {
 		s.cluster.ShardDistributor = d
+		// Add nodes in cluster to shard distributor.
+		for _, id := range s.cluster.nodeIDs() {
+			if err := d.AddNode(id); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 }

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -108,7 +108,7 @@ func TestHandler_Endpoints(t *testing.T) {
 
 	t.Run("PostSchema", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		h.ServeHTTP(w, test.MustNewHTTPRequest("POST", "/schema", strings.NewReader(`{"indexes":[{"name":"blah","options":{"keys":false,"trackExistence":true},"fields":[{"name":"f1","options":{"type":"set","cacheType":"ranked","cacheSize":50000,"keys":false}}],"shardWidth":1048576}]}`)))
+		h.ServeHTTP(w, test.MustNewHTTPRequest("POST", "/schema", strings.NewReader(`{"indexes":[{"name":"blah","options":{"keys":false,"trackExistence":true,"shardDistributor":"jump"},"fields":[{"name":"f1","options":{"type":"set","cacheType":"ranked","cacheSize":50000,"keys":false}}],"shardWidth":1048576}]}`)))
 		if w.Code != gohttp.StatusNoContent {
 			bod, err := ioutil.ReadAll(w.Result().Body)
 			if err != nil {
@@ -194,7 +194,7 @@ func TestHandler_Endpoints(t *testing.T) {
 			t.Fatalf("unexpected status code: %d", w.Code)
 		}
 		body := w.Body.String()
-		target := fmt.Sprintf(`{"indexes":[{"name":"i0","options":{"keys":false,"trackExistence":false},"fields":[{"name":"f0","options":{"type":"set","cacheType":"ranked","cacheSize":50000,"keys":false}},{"name":"f1","options":{"type":"set","cacheType":"ranked","cacheSize":50000,"keys":false}}],"shardWidth":%d},{"name":"i1","options":{"keys":false,"trackExistence":false},"fields":[{"name":"f0","options":{"type":"set","cacheType":"ranked","cacheSize":50000,"keys":false}}],"shardWidth":%[1]d}]}
+		target := fmt.Sprintf(`{"indexes":[{"name":"i0","options":{"keys":false,"trackExistence":false,"shardDistributor":"jump"},"fields":[{"name":"f0","options":{"type":"set","cacheType":"ranked","cacheSize":50000,"keys":false}},{"name":"f1","options":{"type":"set","cacheType":"ranked","cacheSize":50000,"keys":false}}],"shardWidth":%d},{"name":"i1","options":{"keys":false,"trackExistence":false,"shardDistributor":"jump"},"fields":[{"name":"f0","options":{"type":"set","cacheType":"ranked","cacheSize":50000,"keys":false}}],"shardWidth":%[1]d}]}
 `, pilosa.ShardWidth)
 		if body != target {
 			t.Fatalf("%s != %s", target, body)

--- a/shard_distributor.go
+++ b/shard_distributor.go
@@ -1,0 +1,5 @@
+// +build !enterprise
+
+package pilosa
+
+func setShardDistributors(s *Server) error { return nil }

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -14,7 +14,22 @@
 
 package test
 
-// modHasher represents a simple, mod-based hashing.
-type ModHasher struct{}
+// ModDistributor represents a simple, mod-based shard distributor.
+type ModDistributor struct {
+	partitionN int
+}
 
-func (*ModHasher) Hash(key uint64, n int) int { return int(key) % n }
+// NewModDistributor returns a new instance of ModDistributor.
+func NewModDistributor(partitionN int) *ModDistributor {
+	return &ModDistributor{partitionN: partitionN}
+}
+
+// NodeOwners satisfies the ShardDistributor interface.
+func (d *ModDistributor) NodeOwners(nodeIDs []string, replicaN int, index string, shard uint64) []string {
+	idx := int(shard % uint64(d.partitionN))
+	owners := make([]string, 0, replicaN)
+	for i := 0; i < replicaN; i++ {
+		owners = append(owners, nodeIDs[(idx+i)%len(nodeIDs)])
+	}
+	return owners
+}

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -33,3 +33,9 @@ func (d *ModDistributor) NodeOwners(nodeIDs []string, replicaN int, index string
 	}
 	return owners
 }
+
+// AddNode is a nop and only exists to satisfy the `ShardDistributor` interface.
+func (d *ModDistributor) AddNode(nodeID string) error { return nil }
+
+// RemoveNode is a nop and only exists to satisfy the `ShardDistributor` interface.
+func (d *ModDistributor) RemoveNode(nodeID string) error { return nil }

--- a/utils_internal_test.go
+++ b/utils_internal_test.go
@@ -90,6 +90,12 @@ func (d *TestModDistributor) NodeOwners(nodeIDs []string, replicaN int, index st
 	return owners
 }
 
+// AddNode is a nop and only exists to satisfy the `ShardDistributor` interface.
+func (d *TestModDistributor) AddNode(nodeID string) error { return nil }
+
+// RemoveNode is a nop and only exists to satisfy the `ShardDistributor` interface.
+func (d *TestModDistributor) RemoveNode(nodeID string) error { return nil }
+
 // ClusterCluster represents a cluster of test nodes, each of which
 // has a Cluster.
 // ClusterCluster implements Broadcaster interface.

--- a/utils_internal_test.go
+++ b/utils_internal_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const MOD = "mod"
+
 // NewTestCluster returns a cluster with n nodes and uses a mod-based hasher.
 func NewTestCluster(n int) *cluster {
 	path, err := ioutil.TempDir("", "pilosa-cluster-")
@@ -36,7 +38,8 @@ func NewTestCluster(n int) *cluster {
 
 	c := newCluster()
 	c.ReplicaN = 1
-	c.ShardDistributor = NewTestModDistributor(defaultPartitionN)
+	c.shardDistributors = map[string]ShardDistributor{MOD: NewTestModDistributor(defaultPartitionN)}
+	c.defaultShardDistributor = MOD
 	c.Path = path
 	c.Topology = newTopology()
 
@@ -238,12 +241,13 @@ func (t *ClusterCluster) addCluster(i int, saveTopology bool) (*cluster, error) 
 	// holder
 	h := NewHolder()
 	h.Path = path
+	h.defaultShardDistributor = MOD
 
 	// cluster
 	c := newCluster()
 	c.ReplicaN = 1
-	// need partitionN
-	c.ShardDistributor = NewTestModDistributor(defaultPartitionN)
+	c.shardDistributors = map[string]ShardDistributor{MOD: NewTestModDistributor(defaultPartitionN)}
+	c.defaultShardDistributor = MOD
 	c.Path = path
 	c.Topology = newTopology()
 	c.holder = h
@@ -262,6 +266,11 @@ func (t *ClusterCluster) addCluster(i int, saveTopology bool) (*cluster, error) 
 
 	// Add this node to the ClusterCluster.
 	t.Clusters = append(t.Clusters, c)
+
+	// Update modulus of modhasher on cluster addition.
+	for _, c := range t.Clusters {
+		c.shardDistributors[MOD] = NewTestModDistributor(len(t.Clusters))
+	}
 
 	return c, nil
 }

--- a/utils_internal_test.go
+++ b/utils_internal_test.go
@@ -70,14 +70,6 @@ func NewTestURIFromHostPort(host string, port uint16) URI {
 	return *uri
 }
 
-// ModHasher represents a simple, mod-based hashing.
-type TestModHasher struct{}
-
-// NewTestModHasher returns a new instance of ModHasher with n buckets.
-func NewTestModHasher() *TestModHasher { return &TestModHasher{} }
-
-func (*TestModHasher) Hash(key uint64, n int) int { return int(key) % n }
-
 // ModDistributor represents a simple, mod-based shard distributor.
 type TestModDistributor struct {
 	partitionN int


### PR DESCRIPTION
## Overview

This PR refactors the Jump consistent hashing implementation to allow using other consistent hashing algorithms. Shard distribution to nodes now happen on a per-index basis, which means different indexes can be distributed using different algorithms.

All pre-existing indexes will default to the current Jump algorithm, while new indexes will be allocated using the default shard distribution algorithm set when the server starts/restarts.

Fixes #2035 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.
- [x] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Add appropriate changelog label to PR (if applicable).

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Make sure PR is tagged with appropriate changelog label.
