### PR TITLE
fragment.go fix some logic errors

### DIFF
--- a/fragment.go
+++ b/fragment.go
@@ -1340,7 +1340,7 @@ func (f *fragment) rangeLT(bitDepth uint, predicate int64, allowEquality bool) (
 	}
 
 	// If predicate is positive, return all positives less than predicate and all negatives.
-	if (predicate >= 0 && allowEquality) || (predicate >= -1 && !allowEquality) {
+	if (predicate > 0) || (predicate = 0 && allowEquality) {
 		pos, err := f.rangeLTUnsigned(b.Difference(f.row(bsiSignBit)), bitDepth, upredicate, allowEquality)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Overview
When dealing with LT function, the old logic will encounter an exception when it encounters two boundaries of 0 and -1.

For example, there is a field called `foo`：
Set(11, foo=-2)
Set(22, foo=-1)
Set(33, foo=0)
When I query `Row(foo < -1)`, I expected to return only one value(-2), but returned three(-2,-1,0).

Fixes #

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Add appropriate changelog label to PR (if applicable).

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Make sure PR is tagged with appropriate changelog label.