### PR TITLE
Fix issue #2161 build lattice makefile target failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG GO_VERSION=latest
 ### Lattice builder ###
 #######################
 
-FROM moleculacorp/nodejs:latest as lattice-builder
+FROM ghcr.io/featurebasedb/nodejs:0.0.1 as lattice-builder
 WORKDIR /lattice
 
 COPY lattice/package.json ./

--- a/lattice/Dockerfile
+++ b/lattice/Dockerfile
@@ -1,4 +1,4 @@
-FROM moleculacorp/nodejs:latest as build
+FROM ghcr.io/featurebasedb/nodejs:0.0.1 as build
 # make sure that your docker settings allow for at least like 4gb of ram, it
 # takes a lot to build this
 WORKDIR /lattice

--- a/lattice/package.json
+++ b/lattice/package.json
@@ -39,9 +39,9 @@
   "devDependencies": {
     "@types/d3-array": "^2.0.0",
     "@types/jest": "^26.0.4",
-    "@types/react": "^16.9.41",
+    "@types/react": "^17.0.0",
     "@types/react-beautiful-dnd": "^13.0.0",
-    "@types/react-dom": "^16.9.8",
+    "@types/react-dom": "^17.0.0",
     "@types/react-router": "^5.1.8",
     "@types/react-router-dom": "^5.1.5",
     "jest-sonar-reporter": "^2.0.0",
@@ -49,6 +49,9 @@
     "react-scripts": "^4.0.3",
     "tslint": "^6.1.2",
     "typescript": "^4.2.2"
+  },
+  "resolutions": { 
+    "@types/react": "^17.0.0" 
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Fix issue #2161 build lattice makefile target failing:

1. point docker image to pull from featurebasedb github registry
2. added resolutions in package.json to use react 17.0.0 through out the UI code