### PR TITLE
WIP: json marshal coded errors for http

### DIFF
--- a/dax/controller/client/client.go
+++ b/dax/controller/client/client.go
@@ -159,7 +159,7 @@ func (c *Client) DatabaseByName(ctx context.Context, orgID dax.OrganizationID, n
 
 	if resp.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, errors.Errorf("status code: %d: %s", resp.StatusCode, b)
+		return nil, errors.Wrapf(errors.UnmarshalJSON(b), "status code: %d", resp.StatusCode)
 	}
 
 	var qdb *dax.QualifiedDatabase

--- a/dax/controller/http/handler.go
+++ b/dax/controller/http/handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/featurebasedb/featurebase/v3/dax"
 	"github.com/featurebasedb/featurebase/v3/dax/controller"
+	"github.com/featurebasedb/featurebase/v3/errors"
 	"github.com/gorilla/mux"
 )
 
@@ -146,7 +147,7 @@ func (s *server) postDatabaseByName(w http.ResponseWriter, r *http.Request) {
 	}
 	resp, err := s.controller.DatabaseByName(ctx, req.OrganizationID, req.Name)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, errors.MarshalJSON(err), http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
@jaffee @paddyjok I took a stab at how we might json-encode/decode a `codedError` so it can cross an http boundary without losing its code/message.

This commit also shows a single example of the http handler and its corresponding client modified to use this. This results in the client method returning a `codedError` which can be compared with the `errors.Is(someCode)` method.

Looking for feedback.