### PR TITLE
FB-1862: Implement Str() scalar string function

### DIFF
--- a/sql3/planner/expression.go
+++ b/sql3/planner/expression.go
@@ -1524,6 +1524,8 @@ func (n *callPlanExpression) Evaluate(currentRow []interface{}) (interface{}, er
 		return n.EvaluateFormat(currentRow)
 	case "CHARINDEX":
 		return n.EvaluateCharIndex(currentRow)
+	case "STR":
+		return n.EvaluateStr(currentRow)
 	default:
 		return nil, sql3.NewErrInternalf("unhandled function name '%s'", n.name)
 	}

--- a/sql3/planner/expressionanalyzercall.go
+++ b/sql3/planner/expressionanalyzercall.go
@@ -277,6 +277,8 @@ func (p *ExecutionPlanner) analyzeCallExpression(call *parser.Call, scope parser
 		return p.analyseFunctionFormat(call, scope)
 	case "CHARINDEX":
 		return p.analyseFunctionCharIndex(call, scope)
+	case "STR":
+		return p.analyseFunctionStr(call, scope)
 	default:
 		return nil, sql3.NewErrCallUnknownFunction(call.Name.NamePos.Line, call.Name.NamePos.Column, call.Name.Name)
 	}

--- a/sql3/planner/inbuiltfunctionsstring.go
+++ b/sql3/planner/inbuiltfunctionsstring.go
@@ -816,6 +816,9 @@ func (n *callPlanExpression) EvaluateStr(currentRow []interface{}) (interface{},
 	}
 
 	coercedValue, err := coerceValue(n.args[0].Type(), parser.NewDataTypeDecimal(4), argOneEval, parser.Pos{})
+	if err != nil {
+		return "", err
+	}
 
 	decimalArgOne, ok := coercedValue.(pql.Decimal)
 	if !ok {

--- a/sql3/planner/inbuiltfunctionsstring.go
+++ b/sql3/planner/inbuiltfunctionsstring.go
@@ -796,6 +796,9 @@ func (p *ExecutionPlanner) analyseFunctionStr(call *parser.Call, scope parser.St
 
 	// the second and third parameters are optional
 	for i := 1; i < len(call.Args); i++ {
+		if typeIsVoid(call.Args[i].DataType()) {
+			return nil, sql3.NewErrLiteralNullNotAllowed(call.Args[i].Pos().Line, call.Args[i].Pos().Column)
+		}
 		if !typeIsInteger(call.Args[i].DataType()) {
 			return nil, sql3.NewErrIntExpressionExpected(call.Args[i].Pos().Line, call.Args[i].Pos().Column)
 		}

--- a/sql3/planner/inbuiltfunctionsstring.go
+++ b/sql3/planner/inbuiltfunctionsstring.go
@@ -822,7 +822,7 @@ func (n *callPlanExpression) EvaluateStr(currentRow []interface{}) (interface{},
 
 	decimalArgOne, ok := coercedValue.(pql.Decimal)
 	if !ok {
-		return nil, sql3.NewErrInternalf("unexpected type conversion '%T'", coercedValue)
+		return nil, sql3.NewErrUnexpectedTypeConversion(0, 0, coercedValue)
 	}
 
 	intArgTwo := int64(10)
@@ -833,7 +833,7 @@ func (n *callPlanExpression) EvaluateStr(currentRow []interface{}) (interface{},
 		}
 		intArgTwo, ok = argEval.(int64)
 		if !ok {
-			return nil, sql3.NewErrInternalf("unexpected type converion %T", argEval)
+			return nil, sql3.NewErrUnexpectedTypeConversion(0, 0, argEval)
 		}
 	}
 
@@ -845,7 +845,7 @@ func (n *callPlanExpression) EvaluateStr(currentRow []interface{}) (interface{},
 		}
 		intArgThree, ok = argEval.(int64)
 		if !ok {
-			return nil, sql3.NewErrInternalf("unexpected type converion %T", argEval)
+			return nil, sql3.NewErrUnexpectedTypeConversion(0, 0, argEval)
 		}
 	}
 

--- a/sql3/test/defs/defs_string_functions.go
+++ b/sql3/test/defs/defs_string_functions.go
@@ -982,5 +982,135 @@ var stringScalarFunctionsTests = TableTest{
 			),
 			Compare: CompareExactOrdered,
 		},
+		{
+			name: "StrIntValue",
+			SQLs: sqls(
+				"select str(12345)",
+			),
+			ExpHdrs: hdrs(
+				hdr("", fldTypeString),
+			),
+			ExpRows: rows(
+				row(string("     12345")),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			name: "StrIntValueAtEdge",
+			SQLs: sqls(
+				"select str(12345, 5)",
+			),
+			ExpHdrs: hdrs(
+				hdr("", fldTypeString),
+			),
+			ExpRows: rows(
+				row(string("12345")),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			name: "StrIntValueWithPrecision",
+			SQLs: sqls(
+				"select str(12345, 5, 5)",
+			),
+			ExpHdrs: hdrs(
+				hdr("", fldTypeString),
+			),
+			ExpRows: rows(
+				row(string("*****")),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			name: "StrDecimalValue",
+			SQLs: sqls(
+				"select str(12345.678)",
+			),
+			ExpHdrs: hdrs(
+				hdr("", fldTypeString),
+			),
+			ExpRows: rows(
+				row(string("     12346")),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			name: "StrDecimalValueAtEdge",
+			SQLs: sqls(
+				"select str(12345.19, 5)",
+			),
+			ExpHdrs: hdrs(
+				hdr("", fldTypeString),
+			),
+			ExpRows: rows(
+				row(string("12345")),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			name: "StrDecimalValueWithPrecision",
+			SQLs: sqls(
+				"select str(12345.789, 8, 2)",
+			),
+			ExpHdrs: hdrs(
+				hdr("", fldTypeString),
+			),
+			ExpRows: rows(
+				row(string("12345.79")),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			name: "StrNegativeDecimalValueWithPrecision",
+			SQLs: sqls(
+				"select str(-2345.789, 8, 2)",
+			),
+			ExpHdrs: hdrs(
+				hdr("", fldTypeString),
+			),
+			ExpRows: rows(
+				row(string("-2345.79")),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			name: "TooFewArgumentsforStr",
+			SQLs: sqls(
+				"select str()",
+			),
+			ExpErr: "'str': count of formal parameters (1) does not match count of actual parameters (0)",
+		},
+		{
+			name: "TooManyArgumentsforStr",
+			SQLs: sqls(
+				"select str(1, 1, 1, 1)",
+			),
+			ExpErr: "'str': count of formal parameters (1) does not match count of actual parameters (4)",
+		},
+		{
+			name: "StrPrecisionLargerThanValue",
+			SQLs: sqls(
+				"select str(1234.99, 10, 200)",
+			),
+			ExpHdrs: hdrs(
+				hdr("", fldTypeString),
+			),
+			ExpRows: rows(
+				row(string("**********")),
+			),
+			Compare: CompareExactOrdered,
+		}, {
+			name: "StrNull",
+			SQLs: sqls(
+				"select str(null)",
+			),
+			ExpHdrs: hdrs(
+				hdr("", fldTypeString),
+			),
+			ExpRows: rows(
+				row(nil),
+			),
+			Compare: CompareExactUnordered,
+		},
 	},
 }


### PR DESCRIPTION
STR() takes in a number and provides a string representation of it

first optional int variable will set a length to pad out to or to fill out with *'s if the number cannot be represented in that space (default 10)

Second optional variable will allow you to set the desired precision (default 0)