### PR TITLE
Stop go test in GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,3 @@ jobs:
 
       - name: go vet
         run: go vet ./...
-
-      - name: test
-        run: go test ./...


### PR DESCRIPTION
These tests are happening in GitLab CI instead.