### PR TITLE
handle comma syntax of inner join

### DIFF
--- a/sql3/parser/ast.go
+++ b/sql3/parser/ast.go
@@ -3802,7 +3802,12 @@ func (c *ParenSource) SourceFromAlias(alias string) Source {
 }
 
 func (c *ParenSource) PossibleOutputColumns() []*SourceOutputColumn {
-	return c.X.PossibleOutputColumns()
+	aliasName := IdentName(c.Alias)
+	poc := c.X.PossibleOutputColumns()
+	for _, pc := range poc {
+		pc.TableName = aliasName
+	}
+	return poc
 }
 
 func (c *ParenSource) OutputColumnNamed(name string) (*SourceOutputColumn, error) {
@@ -3817,11 +3822,10 @@ func (c *ParenSource) OutputColumnQualifierNamed(qualifier string, name string) 
 }
 
 type JoinClause struct {
-	X             Source                // lhs source
-	Operator      *JoinOperator         // join operator
-	Y             Source                // rhs source
-	Constraint    JoinConstraint        // join constraint
-	OutputColumns []*SourceOutputColumn // output columns - populated during analysis
+	X          Source         // lhs source
+	Operator   *JoinOperator  // join operator
+	Y          Source         // rhs source
+	Constraint JoinConstraint // join constraint
 }
 
 // Clone returns a deep copy of c.
@@ -3847,7 +3851,11 @@ func (c *JoinClause) String() string {
 }
 
 func (c *JoinClause) PossibleOutputColumns() []*SourceOutputColumn {
-	return c.OutputColumns
+	poc := make([]*SourceOutputColumn, 0)
+	poc = append(poc, c.X.PossibleOutputColumns()...)
+	poc = append(poc, c.Y.PossibleOutputColumns()...)
+	return poc
+
 }
 
 func (c *JoinClause) OutputColumnNamed(name string) (*SourceOutputColumn, error) {

--- a/sql3/planner/opnestedloops.go
+++ b/sql3/planner/opnestedloops.go
@@ -36,7 +36,9 @@ func (p *PlanOpNestedLoops) Plan() map[string]interface{} {
 	result["_schema"] = p.Schema().Plan()
 	result["top"] = p.top.Plan()
 	result["bottom"] = p.bottom.Plan()
-	result["condition"] = p.cond.Plan()
+	if p.cond != nil {
+		result["condition"] = p.cond.Plan()
+	}
 	return result
 }
 
@@ -93,10 +95,9 @@ func (p *PlanOpNestedLoops) Expressions() []types.PlanExpression {
 }
 
 func (p *PlanOpNestedLoops) WithUpdatedExpressions(exprs ...types.PlanExpression) (types.PlanOperator, error) {
-	if len(exprs) != 1 {
-		return nil, sql3.NewErrInternalf("unexpected number of exprs '%d'", len(exprs))
+	if len(exprs) == 1 {
+		p.cond = exprs[0]
 	}
-	p.cond = exprs[0]
 	return p, nil
 }
 

--- a/sql3/planner/planoptimizer.go
+++ b/sql3/planner/planoptimizer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/featurebasedb/featurebase/v3/sql3/planner/types"
 )
 
+//TODO(pok) push filter down into join condition if terms reference either side of join
 //TODO(pok) push order by down as far as possible
 //TODO(pok) handle the case of the order by expressions not being in a projection list
 //TODO(pok) you can't group by _id in PQL, so we need to not use a PQL group by operator here

--- a/sql3/test/defs/defs.go
+++ b/sql3/test/defs/defs.go
@@ -170,8 +170,8 @@ var TableTests []TableTest = []TableTest{
 	//bool (batch logic)
 	boolTests,
 
-	//time quantums
-	// Skip for now - timeQuantumInsertTest,
+	// time quantums
+	timeQuantumInsertTest,
 }
 
 func knownTimestamp() time.Time {

--- a/sql3/test/defs/defs_join.go
+++ b/sql3/test/defs/defs_join.go
@@ -137,6 +137,24 @@ var joinTests = TableTest{
 			),
 			ExpErr: "RIGHT join types are not supported",
 		},
+		{
+			name: "commajoin",
+			SQLs: sqls(
+				"select u._id, u.name, u.age, u2._id as u2_id, u2.name as u2name, u2.age as u2age from users u, (select * from users where _id=2) u2 where u._id=u2._id;",
+			),
+			ExpHdrs: hdrs(
+				hdr("_id", fldTypeID),
+				hdr("name", fldTypeString),
+				hdr("age", fldTypeInt),
+				hdr("u2_id", fldTypeID),
+				hdr("u2name", fldTypeString),
+				hdr("u2age", fldTypeInt),
+			),
+			ExpRows: rows(
+				row(int64(2), string("c"), int64(28), int64(2), string("c"), int64(28)),
+			),
+			Compare: CompareExactUnordered,
+		},
 	},
 	PQLTests: []PQLTest{
 		{

--- a/sql3/test/defs/defs_timequantum.go
+++ b/sql3/test/defs/defs_timequantum.go
@@ -9,7 +9,6 @@ var timeQuantumInsertTest = TableTest{
 			srcHdr("i1", fldTypeInt, "min 0", "max 1000"),
 			srcHdr("ids1", fldTypeIDSet, "timequantum 'YMD'"),
 		),
-		srcRows(),
 	),
 	SQLTests: []SQLTest{
 		{


### PR DESCRIPTION
## Overview

This PR handles the comma case of inner join as well as a subquery as a source.  It also correctly handles the case of a nested loops operator not having a join expression in the optimizer.