### PR TITLE
timestamp fixes

### DIFF
--- a/sql3/planner/opbulkinsert.go
+++ b/sql3/planner/opbulkinsert.go
@@ -300,8 +300,9 @@ func (i *bulkInsertSourceCSVRowIter) Next(ctx context.Context) (types.Row, error
 				} else {
 					return nil, sql3.NewErrTypeConversionOnMap(0, 0, evalValue, mapColumn.colType.TypeDescription())
 				}
+			} else {
+				result[idx] = time.UnixMilli(intVal).UTC()
 			}
-			result[idx] = time.UnixMilli(intVal).UTC()
 
 		case *parser.DataTypeString:
 			result[idx] = evalValue

--- a/sql3/sql_test.go
+++ b/sql3/sql_test.go
@@ -62,6 +62,8 @@ func TestSQL_Execute(t *testing.T) {
 								m[headers[i].Name] = i
 							}
 
+							// TODO(pok) - this will become increasingly problematic as result column headers
+							// are not unique and can be empty
 							// Put the expRows in the same column order as the headers returned
 							// by the query.
 							exp := make([][]interface{}, len(sqltest.ExpRows))

--- a/sql3/test/defs/defs.go
+++ b/sql3/test/defs/defs.go
@@ -167,6 +167,10 @@ var TableTests []TableTest = []TableTest{
 	joinTestsOrders,
 	joinTests,
 
+	// bulk insert
+	bulkInsertTable,
+	bulkInsert,
+
 	//bool (batch logic)
 	boolTests,
 
@@ -176,6 +180,14 @@ var TableTests []TableTest = []TableTest{
 
 func knownTimestamp() time.Time {
 	tm, err := time.ParseInLocation(time.RFC3339, "2012-11-01T22:08:41+00:00", time.UTC)
+	if err != nil {
+		panic(err.Error())
+	}
+	return tm
+}
+
+func timestampFromString(s string) time.Time {
+	tm, err := time.ParseInLocation(time.RFC3339, s, time.UTC)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/sql3/test/defs/defs_aggregate.go
+++ b/sql3/test/defs/defs_aggregate.go
@@ -427,14 +427,15 @@ var minmaxTests = TableTest{
 			srcHdr("i1", fldTypeInt, "min 0", "max 1000"),
 			srcHdr("d1", fldTypeDecimal2),
 			srcHdr("s1", fldTypeString),
+			srcHdr("ts1", fldTypeTimestamp),
 		),
 		srcRows(
-			srcRow(int64(1), int64(10), float64(10), string("foo")),
-			srcRow(int64(2), int64(10), float64(10), string("foo")),
-			srcRow(int64(3), int64(11), float64(11), string("foo")),
-			srcRow(int64(4), int64(12), float64(12), string("foo")),
-			srcRow(int64(5), int64(12), float64(12), string("foo")),
-			srcRow(int64(6), int64(13), float64(13), string("foo")),
+			srcRow(int64(1), int64(10), float64(10), string("foo"), timestampFromString("2013-07-15T01:18:46Z")),
+			srcRow(int64(2), int64(10), float64(10), string("foo"), timestampFromString("2014-07-15T01:18:46Z")),
+			srcRow(int64(3), int64(11), float64(11), string("foo"), timestampFromString("2015-07-15T01:18:46Z")),
+			srcRow(int64(4), int64(12), float64(12), string("foo"), timestampFromString("2016-07-15T01:18:46Z")),
+			srcRow(int64(5), int64(12), float64(12), string("foo"), timestampFromString("2017-07-15T01:18:46Z")),
+			srcRow(int64(6), int64(13), float64(13), string("foo"), timestampFromString("2018-07-15T01:18:46Z")),
 		),
 	),
 	SQLTests: []SQLTest{
@@ -518,6 +519,19 @@ var minmaxTests = TableTest{
 			),
 			ExpRows: rows(
 				row(pql.NewDecimal(1300, 2)),
+			),
+			Compare: CompareExactUnordered,
+		},
+		{
+			SQLs: sqls(
+				"select min(ts1) as min_val, max(ts1) as max_val from minmax_test",
+			),
+			ExpHdrs: hdrs(
+				hdr("min_val", fldTypeTimestamp),
+				hdr("max_val", fldTypeTimestamp),
+			),
+			ExpRows: rows(
+				row(timestampFromString("2013-07-15T01:18:46Z"), timestampFromString("2018-07-15T01:18:46Z")),
 			),
 			Compare: CompareExactUnordered,
 		},

--- a/sql3/test/defs/defs_bulkinsert.go
+++ b/sql3/test/defs/defs_bulkinsert.go
@@ -1,0 +1,59 @@
+package defs
+
+// join tests
+var bulkInsertTable = TableTest{
+	name: "bulkInsertTable",
+	Table: tbl(
+		"bulktest",
+		srcHdrs(
+			srcHdr("_id", fldTypeString),
+			srcHdr("id_col", fldTypeID),
+			srcHdr("string_col", fldTypeString),
+			srcHdr("int_col", fldTypeInt),
+			srcHdr("decimal_col", fldTypeDecimal2),
+			srcHdr("bool_col", fldTypeBool),
+			srcHdr("time_col", fldTypeTimestamp),
+			srcHdr("stringset_col", fldTypeStringSet),
+			srcHdr("idset_col", fldTypeIDSet),
+		),
+	),
+	SQLTests: nil,
+}
+
+var bulkInsert = TableTest{
+	name: "bulkInsert",
+	SQLTests: []SQLTest{
+		{
+			name: "timestamp-csv-text",
+			SQLs: sqls(
+				`BULK INSERT INTO 
+					bulktest (_id, id_col, string_col, int_col,decimal_col, bool_col, time_col, stringset_col, idset_col)
+					map (0 ID, 1 STRING, 2 INT, 3 DECIMAL(2), 4 BOOL, 5 TIMESTAMP, 6 STRINGSET, 7 IDSET)
+					transform(@1, @0, @1, @2, @3, @4, @5, @6, @7)
+					FROM x'1,TEST,-123,1.12,0,2013-07-15T01:18:46Z,stringset1, 1
+					2,TEST2,321,31.2,1,2014-07-15T01:18:46Z,stringset1, 1
+					1,TEST,-123,1.12,0,2013-07-15T01:18:46Z,stringset2, 2'
+					with
+						BATCHSIZE 10000
+						format 'CSV'
+						input 'STREAM';`,
+			),
+			ExpHdrs: hdrs(),
+			ExpRows: rows(),
+			Compare: CompareExactOrdered,
+		},
+		{
+			name: "leftjoin",
+			SQLs: sqls(
+				"select time_col from bulktest where _id = 'TEST2';",
+			),
+			ExpHdrs: hdrs(
+				hdr("time_col", fldTypeTimestamp),
+			),
+			ExpRows: rows(
+				row(timestampFromString("2014-07-15T01:18:46Z")),
+			),
+			Compare: CompareExactOrdered,
+		},
+	},
+}


### PR DESCRIPTION
## Overview

This PR fixes:

1. string representations of timestamps in CSV files now ingest the timestamp, and not 0 as it was previously
2. min and max on timestamps (where these are pushed down into PQL min/max operators

The requisite testing has been added.