### PR TITLE
parquet-info command to browse parquet files

### DIFF
--- a/arrow.go
+++ b/arrow.go
@@ -158,8 +158,13 @@ func (st *BasicTable) Release() {
 func (st *BasicTable) Get(column, row int) interface{} {
 	field := st.Schema().Field(column)
 	c, i := st.resolver.Resolve(row)
+	nullable := field.Nullable
 
 	chunk := st.Column(column).Data().Chunk(c)
+	// TODO(twg) 2023/01/26 potential NULL support?
+	if nullable && chunk.IsNull(i) {
+		return nil
+	}
 	switch field.Type.(type) {
 	case *arrow.BooleanType:
 		return chunk.(*array.Boolean).Value(i)

--- a/cmd/parquet-info.go
+++ b/cmd/parquet-info.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Molecula Corp. (DBA FeatureBase).
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/featurebasedb/featurebase/v3/ctl"
+	"github.com/featurebasedb/featurebase/v3/logger"
+	"github.com/spf13/cobra"
+)
+
+func newParquetInfoCommand(logdest logger.Logger) *cobra.Command {
+	c := ctl.NewParquetInfoCommand(logdest)
+	cmd := &cobra.Command{
+		Use:   "parquet-info PATH|URL",
+		Short: "Inspect Parquet Files.",
+		Long: `
+Displays schema and sample data from the specified file
+`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("data directory path required")
+			} else if len(args) > 1 {
+				return fmt.Errorf("too many command line arguments")
+			}
+			c.Path = args[0]
+			return nil
+		},
+		RunE: usageErrorWrapper(c),
+	}
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,6 +108,7 @@ at https://docs.featurebase.com/.
 	rc.AddCommand(newDAXCommand(stderr))
 	rc.AddCommand(newDataframeCsvLoaderCommand(logdest))
 	rc.AddCommand(newPreSortCommand(logdest))
+	rc.AddCommand(newParquetInfoCommand(logdest))
 
 	rc.SetOutput(stderr)
 	return rc

--- a/ctl/parquet-info.go
+++ b/ctl/parquet-info.go
@@ -36,7 +36,7 @@ func NewParquetInfoCommand(logdest logger.Logger) *ParquetInfoCommand {
 	}
 }
 
-// Run displays information about a
+// Run displays schema and samples data from a parquet file
 func (cmd *ParquetInfoCommand) Run(ctx context.Context) error {
 	// Open database.
 	var f *os.File

--- a/ctl/parquet-info.go
+++ b/ctl/parquet-info.go
@@ -1,0 +1,119 @@
+// Copyright 2022 Molecula Corp. (DBA FeatureBase).
+// SPDX-License-Identifier: Apache-2.0
+package ctl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/apache/arrow/go/v10/arrow/memory"
+	"github.com/apache/arrow/go/v10/parquet/file"
+	"github.com/apache/arrow/go/v10/parquet/pqarrow"
+	pilosa "github.com/featurebasedb/featurebase/v3"
+	"github.com/featurebasedb/featurebase/v3/logger"
+)
+
+// ParquetInfoCommand represents a command for displaying info about a parquet file
+type ParquetInfoCommand struct {
+	// Filepath or URL  to the parquet file.
+	Path string
+
+	// Standard input/output
+	stdout  io.Writer
+	logDest logger.Logger
+}
+
+// NewParquetInfoCommand returns a new instance of ParquetInfoCommand.
+func NewParquetInfoCommand(logdest logger.Logger) *ParquetInfoCommand {
+	return &ParquetInfoCommand{
+		stdout:  os.Stdout,
+		logDest: logdest,
+	}
+}
+
+// Run displays information about a
+func (cmd *ParquetInfoCommand) Run(ctx context.Context) error {
+	// Open database.
+	var f *os.File
+	_, err := url.ParseRequestURI(cmd.Path)
+	if err == nil { // treat as a URL
+		response, err := http.Get(cmd.Path)
+		if err != nil {
+			return err
+		}
+		if response.StatusCode != 200 {
+			return errors.New(fmt.Sprintf("unexpected response %d", response.StatusCode))
+		}
+		defer response.Body.Close()
+		// download to temp file first
+		f, err = os.CreateTemp("", "BulkParquetFile.parquet")
+		if err != nil {
+			return errors.New(fmt.Sprintf("error creating tempfile %v", err))
+		}
+		_, err = io.Copy(f, response.Body)
+		if err != nil {
+			return errors.New(fmt.Sprintf("error downloading url %v %v", cmd.Path, err))
+		}
+		defer os.Remove(f.Name())
+
+		_, err = f.Seek(0, io.SeekStart)
+		if err != nil {
+			return errors.New(fmt.Sprintf("error reseting file for reading %v ", err))
+		}
+	} else {
+		f, err = os.Open(cmd.Path)
+		if err != nil {
+			return err
+		}
+	}
+
+	pf, err := file.NewParquetReader(f)
+	if err != nil {
+		return err
+	}
+	mem := memory.NewGoAllocator()
+	reader, err := pqarrow.NewFileReader(pf, pqarrow.ArrowReadProperties{}, mem)
+	if err != nil {
+		return err
+	}
+	table, err := reader.ReadTable(ctx)
+	if err != nil {
+		return err
+	}
+	// print file name
+	fmt.Printf("\n\nName:%v\n", cmd.Path)
+	// print schema
+	schema := table.Schema()
+	fields := schema.Fields()
+	for i, field := range fields {
+		fmt.Printf("%v. Name: %v\n", i, field.Name)
+		fmt.Printf("%v. Type: %v\n", i, field.Type)
+		fmt.Printf("%v. Nullable: %v\n\n", i, field.Nullable)
+	}
+	bt := pilosa.BasicTableFromArrow(table, mem)
+	// print num rows
+	numRows := int(bt.NumRows())
+	fmt.Printf("Number of rows:%v\n", numRows)
+	if numRows > 10 {
+		numRows = 10
+	}
+	fmt.Println("Sample:")
+	// print at most 10 sample rows in table format
+	for _, field := range fields {
+		fmt.Printf("%v\t", field.Name)
+	}
+	fmt.Println("")
+	for i := 0; i < numRows; i++ {
+		for j := 0; j < len(fields); j++ {
+			fmt.Printf("%v\t", bt.Get(j, i))
+		}
+		fmt.Println("")
+	}
+
+	return nil
+}


### PR DESCRIPTION
provide a simple featurebase command to be able to inspect parquet files, it looks something like. this
```
❯ featurebase parquet-info ../data.parquet


Name:../data.parquet
0. Name: vendor_id
0. Type: utf8
0. Nullable: true

1. Name: pickup_at
1. Type: timestamp[us, tz=UTC]
1. Nullable: true

2. Name: dropoff_at
2. Type: timestamp[us, tz=UTC]
2. Nullable: true

3. Name: passenger_count
3. Type: int8
3. Nullable: true

4. Name: trip_distance
4. Type: float32
4. Nullable: true

5. Name: pickup_longitude
5. Type: float32
5. Nullable: true

6. Name: pickup_latitude
6. Type: float32
6. Nullable: true

7. Name: rate_code_id
7. Type: null
7. Nullable: true

8. Name: store_and_fwd_flag
8. Type: utf8
8. Nullable: true

9. Name: dropoff_longitude
9. Type: float32
9. Nullable: true

10. Name: dropoff_latitude
10. Type: float32
10. Nullable: true

11. Name: payment_type
11. Type: utf8
11. Nullable: true

12. Name: fare_amount
12. Type: float32
12. Nullable: true

13. Name: extra
13. Type: float32
13. Nullable: true

14. Name: mta_tax
14. Type: float32
14. Nullable: true

15. Name: tip_amount
15. Type: float32
15. Nullable: true

16. Name: tolls_amount
16. Type: float32
16. Nullable: true

17. Name: total_amount
17. Type: float32
17. Nullable: true

Number of rows:14092413
Sample:
vendor_id       pickup_at       dropoff_at      passenger_count trip_distance   pickup_longitude        pickup_latitude rate_code_id    store_and_fwd_flag      dropoff_longitude       dropoff_latitude        payment_type    fare_amount     extra   mta_tax tip_amount      tolls_amount    total_amount
VTS     0       0       1       2.630000114440918       -73.99195861816406      40.72156524658203       0               -73.99380493164062      40.6959228515625        CASH    8.899999618530273       0.5     0       0       0       9.399999618530273
VTS     0       0       3       4.550000190734863       -73.98210144042969      40.736289978027344      0               -73.95584869384766      40.768028259277344      Credit  12.100000381469727      0.5     0       2       0       14.600000381469727
VTS     0       0       5       10.350000381469727      -74.0025863647461       40.73974609375  0               -73.86997985839844      40.770225524902344      Credit  23.700000762939453      0       0       4.739999771118164       0       28.440000534057617
DDS     0       0       1       5       -73.9742660522461       40.79095458984375       0               -73.9965591430664       40.731849670410156      CREDIT  14.899999618530273      0.5     0       3.049999952316284       0       18.450000762939453
DDS     0       0       1       0.4000000059604645      -74.00157928466797      40.719383239746094      0               -74.00837707519531      40.7203483581543        CASH    3.700000047683716       0       0       0       0       3.700000047683716
DDS     0       0       2       1.2000000476837158      -73.98980712890625      40.73500442504883       0               -73.98502349853516      40.72449493408203       CASH    6.099999904632568       0.5     0       0       0       6.599999904632568
DDS     0       0       1       0.4000000059604645      -73.98404693603516      40.74354553222656       0               -73.98026275634766      40.748924255371094      CREDIT  5.699999809265137       0       0       1       0       6.699999809265137
VTS     0       0       1       1.7200000286102295      -73.99263763427734      40.74836349487305       0               -73.9955825805664       40.72830581665039       CASH    6.099999904632568       0.5     0       0       0       6.599999904632568
CMT     0       0       1       1.600000023841858       -73.96968841552734      40.749244689941406      0               -73.99040985107422      40.75108337402344       Credit  8.699999809265137       0       0       1.2999999523162842      0       10
CMT     0       0       1       0.699999988079071       -73.95516967773438      40.783042907714844      0               -73.9585952758789       40.77482223510742       Cash    5.900000095367432       0       0       0       0       5.900000095367432
```