### PR TITLE
tweak a bunch of logging and config

### DIFF
--- a/dax/computer/service/computer.go
+++ b/dax/computer/service/computer.go
@@ -35,7 +35,7 @@ func New(addr dax.Address, cfg CommandConfig, logger logger.Logger) *computerSer
 	return &computerService{
 		addr:   addr,
 		cfg:    cfg,
-		logger: logger,
+		logger: logger.WithPrefix("Computer: "),
 	}
 }
 

--- a/dax/controller/controller.go
+++ b/dax/controller/controller.go
@@ -108,7 +108,7 @@ func (c *Controller) Start() error {
 	c.poller.Run()
 
 	go c.nodeRegistrationRoutine(c.nodeChan, c.registrationBatchTimeout)
-	go c.snappingTurtleRoutine(c.snappingTurtleTimeout, c.snapControl)
+	go c.snappingTurtleRoutine(c.snappingTurtleTimeout, c.snapControl, c.logger.WithPrefix("Snapping Turtle: "))
 
 	return nil
 }

--- a/dax/controller/node_registerer.go
+++ b/dax/controller/node_registerer.go
@@ -43,10 +43,9 @@ func (c *Controller) nodeRegistrationDelayed(nodes chan *dax.Node, timeout time.
 		case <-c.stopping:
 			return nil
 		case node := <-nodes:
-			c.logger.Debugf("adding node: %+v", node)
+			c.logger.Printf("Adding node to registration batch: %+v", node)
 			batch = append(batch, node)
 		case <-time.After(timeout):
-			c.logger.Debugf("no new nodes in last %s, batch: %d", timeout, len(batch))
 			if len(batch) > 0 {
 				err := c.RegisterNodes(context.Background(), batch...)
 				if err != nil {

--- a/dax/controller/service/controller.go
+++ b/dax/controller/service/controller.go
@@ -35,7 +35,7 @@ func New(uri *fbnet.URI, cfg controller.Config) *controllerService {
 	// Set up logger.
 	var logr logger.Logger = logger.StderrLogger
 	if cfg.Logger != nil {
-		logr = cfg.Logger
+		logr = cfg.Logger.WithPrefix("Controller: ")
 	}
 
 	// Storage methods.

--- a/dax/queryer/service/queryer.go
+++ b/dax/queryer/service/queryer.go
@@ -25,7 +25,7 @@ func New(uri *fbnet.URI, queryer *queryer.Queryer, logger logger.Logger) *querye
 	return &queryerService{
 		uri:     uri,
 		queryer: queryer,
-		logger:  logger,
+		logger:  logger.WithPrefix("Queryer: "),
 	}
 }
 

--- a/dax/server/config.go
+++ b/dax/server/config.go
@@ -71,7 +71,7 @@ func NewConfig() *Config {
 			Config: controller.Config{
 				RegistrationBatchTimeout: time.Second * 3,
 				StorageMethod:            defaultStorageMethod,
-				SnappingTurtleTimeout:    time.Second * 10,
+				SnappingTurtleTimeout:    time.Minute * 3,
 			},
 		},
 		Bind: ":" + defaultBindPort,

--- a/dax/server/server.go
+++ b/dax/server/server.go
@@ -12,7 +12,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"io"
-	"log"
 	"math/rand"
 	"net"
 	"os"
@@ -73,7 +72,7 @@ func OptCommandConfig(config *Config) CommandOption {
 
 // OptCommandServiceManager allows the ability to pass in a ServiceManage that
 // has been initialized outside of the Command. This is useful for testing where
-// we want to controll the service manager during a test run.
+// we want to control the service manager during a test run.
 func OptCommandServiceManager(svcmgr *dax.ServiceManager) CommandOption {
 	return func(c *Command) error {
 		c.svcmgr = svcmgr
@@ -111,7 +110,6 @@ func (m *Command) Start() (err error) {
 	if seed == 0 {
 		seed = time.Now().UTC().UnixNano()
 	}
-	log.Printf("Random seed: %d", seed)
 	rand.Seed(seed)
 
 	if err := m.setupServer(); err != nil {
@@ -217,7 +215,7 @@ func (m *Command) setupServer() error {
 	if err != nil {
 		return errors.Wrap(err, "marshalling config")
 	}
-	m.logger.Printf("Config: %s", conf)
+	m.logger.Debugf("Config: %s", conf)
 
 	// validateAddrs sets the appropriate values for Bind and Advertise
 	// based on the inputs. It is not responsible for applying defaults, although

--- a/dax/service_manager.go
+++ b/dax/service_manager.go
@@ -100,8 +100,10 @@ func (s *ServiceManager) StopAll() error {
 // ControllerStart starts the Controller service.
 func (s *ServiceManager) ControllerStart() error {
 	if s.Controller == nil {
+		s.Logger.Debugf("Skipping Controller")
 		return nil
 	}
+	s.Logger.Printf("Starting Controller")
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -126,6 +128,7 @@ func (s *ServiceManager) ControllerStop() error {
 	if s.Controller == nil {
 		return nil
 	}
+	s.Logger.Printf("Stopping Controller")
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -148,8 +151,10 @@ func (s *ServiceManager) ControllerStop() error {
 // QueryerStart starts the Queryer service.
 func (s *ServiceManager) QueryerStart() error {
 	if s.Queryer == nil {
+		s.Logger.Debugf("Skipping Queryer")
 		return nil
 	}
+	s.Logger.Printf("Starting Queryer")
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -174,6 +179,7 @@ func (s *ServiceManager) QueryerStop() error {
 	if s.Queryer == nil {
 		return nil
 	}
+	s.Logger.Printf("Stopping Queryer")
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -207,6 +213,8 @@ func (s *ServiceManager) ComputerStart(key ServiceKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.Logger.Printf("Starting Computer: %s", key)
+
 	serviceState, ok := s.computers[key]
 	if !ok {
 		return errors.Errorf("computer to be started does not exist: %s", key)
@@ -237,6 +245,8 @@ func (s *ServiceManager) ComputerStart(key ServiceKey) error {
 func (s *ServiceManager) ComputerStop(key ServiceKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	s.Logger.Printf("Stopping Computer: %s", key)
 
 	serviceState, ok := s.computers[key]
 	if !ok {

--- a/diagnostics_internal_test.go
+++ b/diagnostics_internal_test.go
@@ -115,7 +115,7 @@ func TestDiagnosticsVersion_Check(t *testing.T) {
 	// Create a new client.
 	d := newDiagnosticsCollector("localhost:10101")
 
-	logs := logger.NewCaptureLogger()
+	logs := logger.NewBufferLogger()
 	d.Logger = logs
 
 	version := "0.1.1"
@@ -126,11 +126,14 @@ func TestDiagnosticsVersion_Check(t *testing.T) {
 	if err != nil {
 		t.Fatalf("checking version: %v", err)
 	}
-	if len(logs.Prints) != 1 {
-		t.Fatalf("expected a version upgrade message")
+
+	allLogs, err := logs.ReadAll()
+	if err != nil {
+		t.Fatalf("reading all logs: %v", err)
 	}
-	if !strings.Contains(logs.Prints[0], "a newer version") {
-		t.Fatalf("expected version upgrade message, got '%s'", logs.Prints[0])
+
+	if !strings.Contains(string(allLogs), "a newer version") {
+		t.Fatalf("expected version upgrade message, got '%s'", allLogs)
 	}
 }
 

--- a/idk/header_test.go
+++ b/idk/header_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/featurebasedb/featurebase/v3/logger"
 )
 
 func TestHeaderToField(t *testing.T) {
@@ -420,4 +422,10 @@ func (r *recordingLogger) Printf(format string, v ...interface{}) {
 }
 func (r *recordingLogger) Debugf(format string, v ...interface{}) {
 	r.debugs = append(r.debugs, fmt.Sprintf(format, v...))
+}
+
+// WithPrefix does nothing for the recording logger... just makes it
+// implement the interface. Do not use.
+func (r *recordingLogger) WithPrefix(prefix string) logger.Logger {
+	panic("unimplemented")
 }

--- a/idk/kafka/source_test.go
+++ b/idk/kafka/source_test.go
@@ -826,6 +826,7 @@ func TestRegistryURLParsing(t *testing.T) {
 	}
 
 	for i, test := range tests {
+		test := test
 		t.Run(fmt.Sprintf("%s-%d", test.name, i), func(t *testing.T) {
 			t.Parallel()
 

--- a/idk/kinesis/logger.go
+++ b/idk/kinesis/logger.go
@@ -232,3 +232,7 @@ func (esl *ErrorStreamLogger) Panicf(format string, v ...interface{}) {
 		esl.base.Errorf(errors.Wrap(err, errMsg).Error())
 	}
 }
+
+func (esl *ErrorStreamLogger) WithPrefix(prefix string) logger.Logger {
+	return NewErrorStreamLogger(esl.base.WithPrefix(prefix), esl.store)
+}

--- a/idk/kinesis/logger_test.go
+++ b/idk/kinesis/logger_test.go
@@ -59,6 +59,10 @@ func (msl *MapStashLogger) Panicf(format string, v ...interface{}) {
 	msl.messages["PANIC"] = append(msl.messages["PANIC"], fmt.Sprintf(format, v...))
 }
 
+func (msl *MapStashLogger) WithPrefix(prefix string) logger.Logger {
+	panic("unimplemented")
+}
+
 // In-memory error store implementation to use in unit tests.
 type MapStashErrorStore struct {
 	storage        map[ErrorType][]string

--- a/server/config.go
+++ b/server/config.go
@@ -382,7 +382,7 @@ func NewConfig() *Config {
 
 		LongQueryTime: toml.Duration(-time.Minute),
 
-		CheckInInterval: 5 * time.Second,
+		CheckInInterval: 60 * time.Second,
 	}
 
 	// Cluster config.

--- a/server/server.go
+++ b/server/server.go
@@ -296,6 +296,7 @@ func (m *Command) StartNoServe(addr dax.Address) (err error) {
 // If the interval period is 0, the check-in is disabled.
 func (m *Command) checkIn(addr dax.Address) {
 	interval := m.Config.CheckInInterval
+	m.logger.Printf("CheckInInterval: %v", interval)
 
 	if interval == 0 {
 		return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -44,6 +44,7 @@ func TestMain_Set_Quick(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
+		i := i
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
make overall logs less verbose and chatty

1 minute computer check-in interval

3 minute snapshot interval

remove CaptureLogger as it has same functionality as buffer logger

add a WithPrefix to the Logger interface so sub-services can have different prefixes