### PR TITLE
(fb-1951) added test for inserts with timestamp + constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ staticcheck.conf
 dax/dax-data
 
 coverage-from-docker
+*.client_id.txt

--- a/sql3/test/defs/defs.go
+++ b/sql3/test/defs/defs.go
@@ -41,6 +41,7 @@ var TableTests []TableTest = []TableTest{
 	stringScalarFunctionsTests,
 
 	insertTest,
+	insertTimestampTest,
 	keyedInsertTest,
 	timestampLiterals,
 	unaryOpExprWithInt,

--- a/sql3/test/defs/defs_inserts.go
+++ b/sql3/test/defs/defs_inserts.go
@@ -154,3 +154,37 @@ var insertTest = TableTest{
 		},
 	},
 }
+
+var insertTimestampTest = TableTest{
+	SQLTests: []SQLTest{
+		{
+			SQLs: sqls(
+				"CREATE TABLE insertTimestampTest (_id id, time timestamp timeunit 'ms' epoch '2022-01-01T00:00:00Z', ids idset, strings stringset);",
+			),
+			ExpHdrs: hdrs(),
+			ExpRows: rows(),
+			Compare: CompareExactUnordered,
+		},
+		{
+			SQLs: sqls(
+				"INSERT INTO insertTimestampTest(_id, time, ids, strings) VALUES (1, '2023-01-01', [6 , 1, 9], ['red', 'blue', 'green']);",
+			),
+			ExpHdrs: hdrs(),
+			ExpRows: rows(),
+			Compare: CompareExactUnordered,
+		},
+		{
+			SQLs: sqls(
+				"select time from insertTimestampTest;",
+			),
+			ExpHdrs: hdrs(
+				hdr("time", fldTypeTimestamp),
+			),
+			ExpRows: rows(
+				row(timestampFromString("2023-01-01T00:00:00Z")),
+			),
+			Compare:        CompareExactUnordered,
+			SortStringKeys: true,
+		},
+	},
+}


### PR DESCRIPTION
This PR adds a test for inserts with timestamp columns that have time unit and epoch constraints.