### PR TITLE
(fb-1903) - Fix SQL Fanout error

### DIFF
--- a/http_handler.go
+++ b/http_handler.go
@@ -1411,6 +1411,8 @@ func (h *Handler) handlePostSQLPlanOperator(w http.ResponseWriter, r *http.Reque
 
 	ctx := r.Context()
 
+	log.Printf("handlePostSQLPlanOperator() headers: %v", r.Header)
+
 	// DEBUG - hang on to the body
 	bodyBytes, err := io.ReadAll(r.Body)
 	log.Printf("handlePostSQLPlanOperator() body: %v s: %s", bodyBytes, string(bodyBytes))
@@ -1476,6 +1478,8 @@ func (h *Handler) handlePostSQL(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+
+	log.Printf("handlePostSQL() headers: %v", r.Header)
 
 	// get the body
 	b, err := io.ReadAll(r.Body)

--- a/http_handler.go
+++ b/http_handler.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"math"
 	"mime"
 	"net"
@@ -1410,8 +1411,19 @@ func (h *Handler) handlePostSQLPlanOperator(w http.ResponseWriter, r *http.Reque
 
 	ctx := r.Context()
 
-	rootOperator, err := h.api.RehydratePlanOperator(ctx, r.Body)
+	// DEBUG - hang on to the body
+	bodyBytes, err := io.ReadAll(r.Body)
+	log.Printf("handlePostSQLPlanOperator() body: %v s: %s", bodyBytes, string(bodyBytes))
+	reader := io.NopCloser(bytes.NewReader(bodyBytes))
 	if err != nil {
+		writeError(err)
+		return
+	}
+
+	rootOperator, err := h.api.RehydratePlanOperator(ctx /*r.Body*/, reader)
+	if err != nil {
+		// DEBUG - dump the body to the log
+
 		writeError(err)
 		return
 	}

--- a/sql3/planner/executionplanner.go
+++ b/sql3/planner/executionplanner.go
@@ -340,6 +340,8 @@ func (e *ExecutionPlanner) remotePlanExec(ctx context.Context, addr string, op t
 	req.Header.Set("User-Agent", "pilosa/"+e.systemAPI.Version())
 	req.Header.Set("X-FeatureBase-Plan-Operator", fmt.Sprintf("%T", op))
 
+	log.Printf("remotePlanExec() headers: %v", req.Header)
+
 	// Execute request against the host.
 	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
 	if err != nil {

--- a/sql3/planner/executionplanner.go
+++ b/sql3/planner/executionplanner.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -325,7 +324,7 @@ func (e *ExecutionPlanner) remotePlanExec(ctx context.Context, addr string, op t
 	}
 
 	// Create HTTP request.
-	u := fmt.Sprintf("%s/sql", addr)
+	u := fmt.Sprintf("%s/sql-exec-graph", addr)
 	req, err := http.NewRequest("POST", u, bytes.NewReader(b))
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request")
@@ -338,9 +337,6 @@ func (e *ExecutionPlanner) remotePlanExec(ctx context.Context, addr string, op t
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Accept", "application/octet-stream")
 	req.Header.Set("User-Agent", "pilosa/"+e.systemAPI.Version())
-	req.Header.Set("X-FeatureBase-Plan-Operator", fmt.Sprintf("%T", op))
-
-	log.Printf("remotePlanExec() headers: %v", req.Header)
 
 	// Execute request against the host.
 	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
@@ -349,20 +345,13 @@ func (e *ExecutionPlanner) remotePlanExec(ctx context.Context, addr string, op t
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := io.ReadAll(resp.Body)
-	log.Printf("remotePlanExec() body: %v s: %s", bodyBytes, string(bodyBytes))
-	reader := io.NopCloser(bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, err
-	}
-
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// we have an error
 		return nil, sql3.NewErrInternalf("error posting internally: %d", resp.StatusCode)
 	}
 
 	var rows types.Rows
-	parser := newWireProtocolParser(e, reader)
+	parser := newWireProtocolParser(e, resp.Body)
 	state := 1
 	for state <= 2 {
 		msg, err := parser.nextMessage()


### PR DESCRIPTION
This PR fixes an issue with header-based routing in the `http_handler` not working on a real cluster. The fix is to route by....well, route.