### PR TITLE
(fb-1978) - performance regression

### DIFF
--- a/sql3/planner/planoptimizer.go
+++ b/sql3/planner/planoptimizer.go
@@ -644,7 +644,13 @@ func tryToReplaceGroupByWithPQLAggregate(ctx context.Context, a *ExecutionPlanne
 					}
 					switch aggregable.AggExpression().Type().(type) {
 					case *parser.DataTypeID, *parser.DataTypeString:
-						return thisNode, true, nil
+						// if it is any other column other than _id bail
+						ref, ok := aggregable.AggExpression().(*qualifiedRefPlanExpression)
+						if ok {
+							if !strings.EqualFold(ref.columnName, "_id") {
+								return thisNode, true, nil
+							}
+						}
 					}
 				}
 


### PR DESCRIPTION
This PR fixes a performance regression with the calculation of aggregates on ID/STRING types.

Currently, count(*) explicitly references the _id column and a recent change to allow non-pql aggregates on ID & STRING types did not take this into account.

This change will short circuit this check to force counts on _id columns to be executed using pql.Call.
