### PR TITLE
ORDER BY ....what now!? (fb-1954)

### DIFF
--- a/sql3/planner/expressiontypes.go
+++ b/sql3/planner/expressiontypes.go
@@ -466,7 +466,7 @@ func typeIsTimeQuantum(testType parser.ExprDataType) (bool, parser.ExprDataType)
 	switch testType.(type) {
 	case *parser.DataTypeIDSetQuantum:
 		return true, parser.NewDataTypeIDSet()
-	case *parser.DataTypeStringSet:
+	case *parser.DataTypeStringSetQuantum:
 		return true, parser.NewDataTypeStringSet()
 	default:
 		return false, nil
@@ -539,6 +539,16 @@ func typeIsBSI(testType parser.ExprDataType) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// returns true if we can sort on a type
+func typeCanBeSortedOn(testType parser.ExprDataType) bool {
+	switch testType.(type) {
+	case *parser.DataTypeStringSet, *parser.DataTypeIDSet:
+		return false
+	default:
+		return true
 	}
 }
 

--- a/sql3/planner/inbuiltfunctionstable.go
+++ b/sql3/planner/inbuiltfunctionstable.go
@@ -47,7 +47,7 @@ func (p *ExecutionPlanner) analyzeFunctionSubtable(call *parser.Call, scope pars
 	ok, _ := typeIsTimeQuantum(call.Args[0].DataType())
 	if !ok {
 		// TODO (pok) send back the right error
-		return nil, sql3.NewErrSetExpressionExpected(call.Args[1].Pos().Line, call.Args[1].Pos().Column)
+		return nil, sql3.NewErrSetExpressionExpected(call.Args[0].Pos().Line, call.Args[0].Pos().Column)
 	}
 	call.ResultDataType = parser.NewDataTypeSubtable([]*parser.SubtableColumn{
 		{

--- a/sql3/test/defs/defs_orderby.go
+++ b/sql3/test/defs/defs_orderby.go
@@ -14,10 +14,10 @@ var orderByTests = TableTest{
 			srcHdr("a_decimal", fldTypeDecimal2),
 		),
 		srcRows(
-			srcRow(int64(1), int64(11), []int64{11, 12, 13}, int64(101), "str1", []string{"a1", "b1", "c1"}, float64(123.45)),
-			srcRow(int64(2), int64(22), []int64{21, 22, 23}, int64(201), "str2", []string{"a2", "b2", "c2"}, float64(234.56)),
-			srcRow(int64(3), int64(33), []int64{31, 32, 33}, int64(301), "str3", []string{"a3", "b3", "c3"}, float64(345.67)),
-			srcRow(int64(4), int64(44), []int64{41, 42, 43}, int64(401), "str4", []string{"a4", "b4", "c4"}, float64(456.78)),
+			srcRow(int64(1), int64(44), []int64{11, 12, 13}, int64(101), "str1", []string{"a1", "b1", "c1"}, float64(123.45)),
+			srcRow(int64(2), int64(33), []int64{21, 22, 23}, int64(201), "str2", []string{"a2", "b2", "c2"}, float64(234.56)),
+			srcRow(int64(3), int64(21), []int64{31, 32, 33}, int64(301), "str3", []string{"a3", "b3", "c3"}, float64(345.67)),
+			srcRow(int64(4), int64(10), []int64{41, 42, 43}, int64(401), "str4", []string{"a4", "b4", "c4"}, float64(456.78)),
 		),
 	),
 	SQLTests: []SQLTest{
@@ -34,6 +34,128 @@ var orderByTests = TableTest{
 				"select * from order_by_test order by an_id_set asc",
 			),
 			ExpErr: "unable to sort a column of type 'idset'",
+		},
+		{
+			SQLs: sqls(
+				"select an_int from order_by_test order by an_id asc",
+			),
+			ExpHdrs: hdrs(
+				hdr("an_int", fldTypeInt),
+			),
+			ExpRows: rows(
+				row(int64(44)),
+				row(int64(33)),
+				row(int64(21)),
+				row(int64(10)),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			SQLs: sqls(
+				"select an_int, an_id from order_by_test order by a_decimal asc",
+			),
+			ExpHdrs: hdrs(
+				hdr("an_int", fldTypeInt),
+				hdr("an_id", fldTypeID),
+			),
+			ExpRows: rows(
+				row(int64(44), int64(101)),
+				row(int64(33), int64(201)),
+				row(int64(21), int64(301)),
+				row(int64(10), int64(401)),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			SQLs: sqls(
+				"select an_int + 1 as foo, an_id from order_by_test order by foo asc, a_decimal asc",
+			),
+			ExpHdrs: hdrs(
+				hdr("foo", fldTypeInt),
+				hdr("an_id", fldTypeID),
+			),
+			ExpRows: rows(
+				row(int64(11), int64(401)),
+				row(int64(22), int64(301)),
+				row(int64(34), int64(201)),
+				row(int64(45), int64(101)),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			SQLs: sqls(
+				"select an_int from order_by_test order by an_int asc",
+			),
+			ExpHdrs: hdrs(
+				hdr("an_int", fldTypeInt),
+			),
+			ExpRows: rows(
+				row(int64(10)),
+				row(int64(21)),
+				row(int64(33)),
+				row(int64(44)),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			SQLs: sqls(
+				"select an_int as foo from order_by_test order by foo asc",
+			),
+			ExpHdrs: hdrs(
+				hdr("foo", fldTypeInt),
+			),
+			ExpRows: rows(
+				row(int64(10)),
+				row(int64(21)),
+				row(int64(33)),
+				row(int64(44)),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			SQLs: sqls(
+				"select an_int as foo from order_by_test order by 1 asc",
+			),
+			ExpHdrs: hdrs(
+				hdr("foo", fldTypeInt),
+			),
+			ExpRows: rows(
+				row(int64(10)),
+				row(int64(21)),
+				row(int64(33)),
+				row(int64(44)),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			SQLs: sqls(
+				"select an_int + 1 from order_by_test order by 1 asc",
+			),
+			ExpHdrs: hdrs(
+				hdr("", fldTypeInt),
+			),
+			ExpRows: rows(
+				row(int64(11)),
+				row(int64(22)),
+				row(int64(34)),
+				row(int64(45)),
+			),
+			Compare: CompareExactOrdered,
+		},
+		{
+			SQLs: sqls(
+				"select an_int + 1 as bar from order_by_test order by bar desc",
+			),
+			ExpHdrs: hdrs(
+				hdr("bar", fldTypeInt),
+			),
+			ExpRows: rows(
+				row(int64(45)),
+				row(int64(34)),
+				row(int64(22)),
+				row(int64(11)),
+			),
+			Compare: CompareExactOrdered,
 		},
 	},
 }


### PR DESCRIPTION
This PR handles the case of a term appearing in the  ORDER BY clause for a term not in the projection list for a SELECT.

Additional compiler behavior has been changed thus:

1. The compiler will now place the PlanOpOrderBy op before the PlanOpProjection op for in cases where there are only references  in the order by expression list (or positional expressions that can be resolved to references.
2. The compiler will also handle the case of a reference appearing in the order by expression list that is not projected.
3. If the order by list contains non reference expressions and references that do not appear in the projection list, the compiler will: a) generate a new projection containing the original projection's schema, b) make the order by operator a child of that projection op and c) make the original projection (with the addition of the unprojected order by expression) a child of the order by operator.

Test coverage has been added to cover these cases.