### PR TITLE
Make count(*) not depend on _id (fb-1974)

### DIFF
--- a/sql3/planner/compilealtertable.go
+++ b/sql3/planner/compilealtertable.go
@@ -92,7 +92,7 @@ func (p *ExecutionPlanner) analyzeAlterTableStatement(stmt *parser.AlterTableSta
 			return sql3.NewErrUnknownType(col.Type.Name.NamePos.Line, col.Type.Name.NamePos.Column, typeName)
 		}
 
-		if strings.ToLower(columnName) == "_id" {
+		if strings.ToLower(columnName) == string(dax.PrimaryKeyFieldName) {
 			//not allowed to add an _id column after the fact
 			return sql3.NewErrTableIDColumnAlter(col.Name.NamePos.Line, col.Name.NamePos.Column)
 		}

--- a/sql3/planner/compilebulkinsert.go
+++ b/sql3/planner/compilebulkinsert.go
@@ -383,7 +383,7 @@ func (p *ExecutionPlanner) analyzeBulkInsertStatement(ctx context.Context, stmt 
 		}
 		columnNameMap[colName] = struct{}{}
 
-		if strings.EqualFold(cm.Name, "_id") {
+		if strings.EqualFold(cm.Name, string(dax.PrimaryKeyFieldName)) {
 			foundID = true
 		}
 	}

--- a/sql3/planner/compilecreatetable.go
+++ b/sql3/planner/compilecreatetable.go
@@ -54,7 +54,7 @@ func (p *ExecutionPlanner) compileCreateTableStatement(ctx context.Context, stmt
 		columnName := strings.ToLower(parser.IdentName(col.Name))
 		typeName := parser.IdentName(col.Type.Name)
 
-		if strings.ToLower(columnName) == "_id" {
+		if strings.ToLower(columnName) == string(dax.PrimaryKeyFieldName) {
 			if strings.EqualFold(typeName, dax.BaseTypeString) {
 				isKeyed = true
 			}
@@ -262,7 +262,7 @@ func (p *ExecutionPlanner) analyzeCreateTableStatement(stmt *parser.CreateTableS
 			return sql3.NewErrUnknownType(col.Type.Name.NamePos.Line, col.Type.Name.NamePos.Column, typeName)
 		}
 
-		if strings.ToLower(columnName) == "_id" {
+		if strings.ToLower(columnName) == string(dax.PrimaryKeyFieldName) {
 			//check the type
 			if !(strings.EqualFold(typeName, dax.BaseTypeID) || strings.EqualFold(typeName, dax.BaseTypeString)) {
 				return sql3.NewErrTableIDColumnType(col.Type.Name.NamePos.Line, col.Type.Name.NamePos.Column)
@@ -279,7 +279,7 @@ func (p *ExecutionPlanner) analyzeCreateTableStatement(stmt *parser.CreateTableS
 			return err
 		}
 	}
-	_, ok := checkedColumns["_id"]
+	_, ok := checkedColumns[string(dax.PrimaryKeyFieldName)]
 	if !ok {
 		return sql3.NewErrTableMustHaveIDColumn(stmt.Create.Line, stmt.Create.Column)
 	}

--- a/sql3/planner/compileinsert.go
+++ b/sql3/planner/compileinsert.go
@@ -33,7 +33,7 @@ func (p *ExecutionPlanner) compileInsertStatement(ctx context.Context, stmt *par
 		for _, columnIdent := range stmt.Columns {
 			colName := strings.ToLower(parser.IdentName(columnIdent))
 
-			if strings.EqualFold(colName, "_id") {
+			if strings.EqualFold(colName, string(dax.PrimaryKeyFieldName)) {
 				targetColumns = append(targetColumns, newQualifiedRefPlanExpression(tableName, colName, 0, parser.NewDataTypeID()))
 				continue
 			}
@@ -111,8 +111,8 @@ func (p *ExecutionPlanner) analyzeInsertStatement(ctx context.Context, stmt *par
 			colName := strings.ToLower(parser.IdentName(columnIdent))
 			var typeName parser.ExprDataType
 
-			if strings.EqualFold(colName, "_id") {
-				columnNameMap["_id"] = struct{}{}
+			if strings.EqualFold(colName, string(dax.PrimaryKeyFieldName)) {
+				columnNameMap[string(dax.PrimaryKeyFieldName)] = struct{}{}
 
 				// Determine, from the existing table, whether the _id is of
 				// type ID or STRING.
@@ -151,7 +151,7 @@ func (p *ExecutionPlanner) analyzeInsertStatement(ctx context.Context, stmt *par
 		}
 
 		// Ensure we have an _id column.
-		if _, ok := columnNameMap["_id"]; !ok {
+		if _, ok := columnNameMap[string(dax.PrimaryKeyFieldName)]; !ok {
 			return sql3.NewErrInsertMustHaveIDColumn(stmt.ColumnsLparen.Line, stmt.ColumnsLparen.Column)
 		}
 

--- a/sql3/planner/compileshow.go
+++ b/sql3/planner/compileshow.go
@@ -23,7 +23,7 @@ func (p *ExecutionPlanner) compileShowDatabasesStatement(ctx context.Context, st
 	columns := []types.PlanExpression{
 		&qualifiedRefPlanExpression{
 			tableName:   "fb_databases",
-			columnName:  "_id",
+			columnName:  string(dax.PrimaryKeyFieldName),
 			columnIndex: 0,
 			dataType:    parser.NewDataTypeString(),
 		},
@@ -82,7 +82,7 @@ func (p *ExecutionPlanner) compileShowTablesStatement(ctx context.Context, stmt 
 	columns := []types.PlanExpression{
 		&qualifiedRefPlanExpression{
 			tableName:   "fb_tables",
-			columnName:  "_id",
+			columnName:  string(dax.PrimaryKeyFieldName),
 			columnIndex: 0,
 			dataType:    parser.NewDataTypeString(),
 		},
@@ -151,7 +151,7 @@ func (p *ExecutionPlanner) compileShowColumnsStatement(ctx context.Context, stmt
 
 	columns := []types.PlanExpression{&qualifiedRefPlanExpression{
 		tableName:   "fb_table_columns",
-		columnName:  "_id",
+		columnName:  string(dax.PrimaryKeyFieldName),
 		columnIndex: 0,
 		dataType:    parser.NewDataTypeString(),
 	}, &qualifiedRefPlanExpression{

--- a/sql3/planner/expression.go
+++ b/sql3/planner/expression.go
@@ -2787,7 +2787,11 @@ func (p *ExecutionPlanner) compileCallExpr(expr *parser.Call) (_ types.PlanExpre
 		if expr.Distinct.IsValid() {
 			agg = newCountDistinctPlanExpression(args[0], expr.ResultDataType)
 		} else {
-			agg = newCountPlanExpression(args[0], expr.ResultDataType)
+			if expr.Star.IsValid() {
+				agg = newCountStarPlanExpression(expr.ResultDataType)
+			} else {
+				agg = newCountPlanExpression(args[0], expr.ResultDataType)
+			}
 		}
 		return agg, nil
 

--- a/sql3/planner/expressionanalyzercall.go
+++ b/sql3/planner/expressionanalyzercall.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/featurebasedb/featurebase/v3/dax"
 	"github.com/featurebasedb/featurebase/v3/sql3"
 	"github.com/featurebasedb/featurebase/v3/sql3/parser"
 )
@@ -22,26 +23,16 @@ func (p *ExecutionPlanner) analyzeCallExpression(ctx context.Context, call *pars
 	}
 	switch strings.ToUpper(call.Name.Name) {
 	case "COUNT":
-		//check to see if we have a star, if we do turn it into a qualified ref to _id
-		if call.Star.IsValid() && len(call.Args) == 0 {
-			newArg := &parser.Ident{
-				NamePos: call.Star,
-				Name:    "_id",
+		if len(call.Args) > 0 && !call.Star.IsValid() {
+			// one argument only
+			if len(call.Args) != 1 {
+				return nil, sql3.NewErrCallParameterCountMismatch(call.Rparen.Line, call.Rparen.Column, call.Name.Name, 1, len(call.Args))
 			}
-			arg, err := p.analyzeExpression(ctx, newArg, scope)
-			if err != nil {
-				return nil, err
+			//make sure it's a qualified ref
+			_, ok := call.Args[0].(*parser.QualifiedRef)
+			if !ok {
+				return nil, sql3.NewErrExpectedColumnReference(call.Args[0].Pos().Line, call.Args[0].Pos().Column)
 			}
-			call.Args = append(call.Args, arg)
-		}
-		// one argument only
-		if len(call.Args) != 1 {
-			return nil, sql3.NewErrCallParameterCountMismatch(call.Rparen.Line, call.Rparen.Column, call.Name.Name, 1, len(call.Args))
-		}
-		//make sure it's a qualified ref
-		_, ok := call.Args[0].(*parser.QualifiedRef)
-		if !ok {
-			return nil, sql3.NewErrExpectedColumnReference(call.Args[0].Pos().Line, call.Args[0].Pos().Column)
 		}
 		//COUNT always returns int
 		call.ResultDataType = parser.NewDataTypeInt()
@@ -58,7 +49,7 @@ func (p *ExecutionPlanner) analyzeCallExpression(ctx context.Context, call *pars
 
 		// if it is a ref, we shouldn't do a sum on the _id
 		ref, ok := call.Args[0].(*parser.QualifiedRef)
-		if ok && strings.EqualFold(ref.Column.Name, "_id") {
+		if ok && strings.EqualFold(ref.Column.Name, string(dax.PrimaryKeyFieldName)) {
 			return nil, sql3.NewErrIdColumnNotValidForAggregateFunction(call.Args[0].Pos().Line, call.Args[0].Pos().Column, call.Name.Name)
 		}
 
@@ -82,7 +73,7 @@ func (p *ExecutionPlanner) analyzeCallExpression(ctx context.Context, call *pars
 
 		// if it is a ref, we shouldn't do a avg on the _id
 		ref, ok := call.Args[0].(*parser.QualifiedRef)
-		if ok && strings.EqualFold(ref.Column.Name, "_id") {
+		if ok && strings.EqualFold(ref.Column.Name, string(dax.PrimaryKeyFieldName)) {
 			return nil, sql3.NewErrIdColumnNotValidForAggregateFunction(call.Args[0].Pos().Line, call.Args[0].Pos().Column, call.Name.Name)
 		}
 
@@ -110,7 +101,7 @@ func (p *ExecutionPlanner) analyzeCallExpression(ctx context.Context, call *pars
 		}
 
 		//can't do a percentile on _id
-		if strings.EqualFold(ref.Column.Name, "_id") {
+		if strings.EqualFold(ref.Column.Name, string(dax.PrimaryKeyFieldName)) {
 			return nil, sql3.NewErrIdColumnNotValidForAggregateFunction(call.Args[0].Pos().Line, call.Args[0].Pos().Column, call.Name.Name)
 		}
 
@@ -146,7 +137,7 @@ func (p *ExecutionPlanner) analyzeCallExpression(ctx context.Context, call *pars
 
 		// if it is a ref, we shouldn't do a min/max on the _id
 		ref, ok := call.Args[0].(*parser.QualifiedRef)
-		if ok && strings.EqualFold(ref.Column.Name, "_id") {
+		if ok && strings.EqualFold(ref.Column.Name, string(dax.PrimaryKeyFieldName)) {
 			return nil, sql3.NewErrIdColumnNotValidForAggregateFunction(call.Args[0].Pos().Line, call.Args[0].Pos().Column, call.Name.Name)
 		}
 

--- a/sql3/planner/expressionpql.go
+++ b/sql3/planner/expressionpql.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/featurebasedb/featurebase/v3/dax"
 	"github.com/featurebasedb/featurebase/v3/pql"
 	"github.com/featurebasedb/featurebase/v3/sql3"
 	"github.com/featurebasedb/featurebase/v3/sql3/parser"
@@ -114,7 +115,7 @@ func (p *ExecutionPlanner) generatePQLCallFromExpr(ctx context.Context, expr typ
 		}
 
 		// if it is the _id column, we can use ConstRow with a list
-		if strings.EqualFold(lhs.columnName, "_id") {
+		if strings.EqualFold(lhs.columnName, string(dax.PrimaryKeyFieldName)) {
 			values := make([]interface{}, len(list.exprs))
 			for i, m := range list.exprs {
 				pqlValue, err := planExprToValue(m)
@@ -204,7 +205,7 @@ func (p *ExecutionPlanner) generatePQLCallFromBinaryExpr(ctx context.Context, ex
 			}, nil
 
 		case *parser.DataTypeID:
-			if strings.EqualFold(lhs.columnName, "_id") {
+			if strings.EqualFold(lhs.columnName, string(dax.PrimaryKeyFieldName)) {
 				return &pql.Call{
 					Name: "ConstRow",
 					Args: map[string]interface{}{
@@ -221,7 +222,7 @@ func (p *ExecutionPlanner) generatePQLCallFromBinaryExpr(ctx context.Context, ex
 			}, nil
 
 		case *parser.DataTypeString:
-			if strings.EqualFold(lhs.columnName, "_id") {
+			if strings.EqualFold(lhs.columnName, string(dax.PrimaryKeyFieldName)) {
 				return &pql.Call{
 					Name: "ConstRow",
 					Args: map[string]interface{}{
@@ -436,8 +437,8 @@ func (p *ExecutionPlanner) generatePQLCallFromBinaryExpr(ctx context.Context, ex
 		}
 		switch typ := expr.lhs.Type().(type) {
 		case *parser.DataTypeID:
-			if strings.EqualFold(lhs.columnName, "_id") {
-				return nil, sql3.NewErrInvalidColumnInFilterExpression(0, 0, "_id", "is/is not null")
+			if strings.EqualFold(lhs.columnName, string(dax.PrimaryKeyFieldName)) {
+				return nil, sql3.NewErrInvalidColumnInFilterExpression(0, 0, string(dax.PrimaryKeyFieldName), "is/is not null")
 			}
 			return nil, sql3.NewErrInvalidTypeInFilterExpression(0, 0, typ.TypeDescription(), "is/is not null")
 

--- a/sql3/planner/expressiontypes.go
+++ b/sql3/planner/expressiontypes.go
@@ -23,7 +23,7 @@ func fieldSQLDataType(f *pilosa.FieldInfo) parser.ExprDataType {
 	// a FieldTypeID. Another thing to be updated is the "_id" value itself; in
 	// the dax package there is a constant called `PrimaryKeyFieldName` which
 	// would be used here instead.
-	if f.Name == "_id" {
+	if f.Name == string(dax.PrimaryKeyFieldName) {
 		switch f.Options.Type {
 		case "id":
 			return parser.NewDataTypeID()

--- a/sql3/planner/inbuiltfunctionstable.go
+++ b/sql3/planner/inbuiltfunctionstable.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"github.com/featurebasedb/featurebase/v3/dax"
 	"github.com/featurebasedb/featurebase/v3/sql3"
 	"github.com/featurebasedb/featurebase/v3/sql3/parser"
 )
@@ -50,7 +51,7 @@ func (p *ExecutionPlanner) analyzeFunctionSubtable(call *parser.Call, scope pars
 	}
 	call.ResultDataType = parser.NewDataTypeSubtable([]*parser.SubtableColumn{
 		{
-			Name:     "_id",
+			Name:     string(dax.PrimaryKeyFieldName),
 			DataType: parser.NewDataTypeID(),
 		},
 		{

--- a/sql3/planner/opcreatetable.go
+++ b/sql3/planner/opcreatetable.go
@@ -106,7 +106,7 @@ func (i *createTableRowIter) Next(ctx context.Context) (types.Row, error) {
 		idType = dax.BaseTypeString
 	}
 	fields = append(fields, &dax.Field{
-		Name: "_id",
+		Name: dax.PrimaryKeyFieldName,
 		Type: idType,
 	})
 

--- a/sql3/planner/opfeaturebasecolumns.go
+++ b/sql3/planner/opfeaturebasecolumns.go
@@ -49,7 +49,7 @@ func (p *PlanOpFeatureBaseColumns) Schema() types.Schema {
 	return types.Schema{
 		&types.PlannerColumn{
 			RelationName: "fb_table_columns",
-			ColumnName:   "_id",
+			ColumnName:   string(dax.PrimaryKeyFieldName),
 			Type:         parser.NewDataTypeString(),
 		},
 		&types.PlannerColumn{

--- a/sql3/planner/opfeaturebasedatabases.go
+++ b/sql3/planner/opfeaturebasedatabases.go
@@ -51,7 +51,7 @@ func (p *PlanOpFeatureBaseDatabases) Schema() types.Schema {
 	return types.Schema{
 		&types.PlannerColumn{
 			RelationName: "fb_databases",
-			ColumnName:   "_id",
+			ColumnName:   string(dax.PrimaryKeyFieldName),
 			Type:         parser.NewDataTypeString(),
 		},
 		&types.PlannerColumn{

--- a/sql3/planner/opfeaturebasetables.go
+++ b/sql3/planner/opfeaturebasetables.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	pilosa "github.com/featurebasedb/featurebase/v3"
+	"github.com/featurebasedb/featurebase/v3/dax"
 	"github.com/featurebasedb/featurebase/v3/sql3/parser"
 	"github.com/featurebasedb/featurebase/v3/sql3/planner/types"
 )
@@ -52,7 +53,7 @@ func (p *PlanOpFeatureBaseTables) Schema() types.Schema {
 	return types.Schema{
 		&types.PlannerColumn{
 			RelationName: "fb_tables",
-			ColumnName:   "_id",
+			ColumnName:   string(dax.PrimaryKeyFieldName),
 			Type:         parser.NewDataTypeString(),
 		},
 		&types.PlannerColumn{

--- a/sql3/planner/opinsert.go
+++ b/sql3/planner/opinsert.go
@@ -116,7 +116,7 @@ func (i *insertRowIter) Next(ctx context.Context) (types.Row, error) {
 			posVals[j] = j - 1
 			continue
 		}
-		if strings.EqualFold(i.targetColumns[j].columnName, "_id") {
+		if strings.EqualFold(i.targetColumns[j].columnName, string(dax.PrimaryKeyFieldName)) {
 			posID = j
 			foundPosID = true
 		}

--- a/sql3/planner/oppqlaggregate.go
+++ b/sql3/planner/oppqlaggregate.go
@@ -42,7 +42,7 @@ func (p *PlanOpPQLAggregate) Plan() map[string]interface{} {
 	if p.filter != nil {
 		result["filter"] = p.filter.Plan()
 	}
-	result["aggregate"] = p.aggregate.FirstChildExpr().Plan()
+	result["aggregate"] = p.aggregate.String()
 	return result
 
 }
@@ -64,7 +64,7 @@ func (p *PlanOpPQLAggregate) Schema() types.Schema {
 	s := &types.PlannerColumn{
 		ColumnName:   "",
 		RelationName: "",
-		Type:         p.aggregate.FirstChildExpr().Type(),
+		Type:         p.aggregate.Type(),
 	}
 	result[0] = s
 	return result
@@ -135,7 +135,7 @@ func (i *pqlAggregateRowIter) Next(ctx context.Context) (types.Row, error) {
 
 			call = &pql.Call{Name: "Count", Children: []*pql.Call{cond}}
 
-		case *countPlanExpression:
+		case *countPlanExpression, *countStarPlanExpression:
 			if cond == nil {
 				// COUNT() should ignore null values
 				// if the data type of the expression supports an existence bitmap for
@@ -156,7 +156,7 @@ func (i *pqlAggregateRowIter) Next(ctx context.Context) (types.Row, error) {
 
 		case *avgPlanExpression:
 			if cond == nil {
-				// COUNT() should ignore null values
+				// SUM() should ignore null values
 				// if the data type of the expression supports an existence bitmap for
 				// the underlying FeatureBase data type use it to eliminate nulls from the aggregate
 				switch expr.dataType.(type) {

--- a/sql3/planner/oppqldelete.go
+++ b/sql3/planner/oppqldelete.go
@@ -102,7 +102,7 @@ func (p *PlanOpPQLConstRowDelete) Expressions() []types.PlanExpression {
 			tableName:   p.tableName,
 			columnIndex: 0,
 			dataType:    colType,
-			columnName:  "_id",
+			columnName:  string(dax.PrimaryKeyFieldName),
 		},
 	}
 }

--- a/sql3/planner/oppqldistinctscan.go
+++ b/sql3/planner/oppqldistinctscan.go
@@ -28,7 +28,7 @@ type PlanOpPQLDistinctScan struct {
 }
 
 func NewPlanOpPQLDistinctScan(p *ExecutionPlanner, tableName string, column string) (*PlanOpPQLDistinctScan, error) {
-	if strings.EqualFold("_id", column) {
+	if strings.EqualFold(string(dax.PrimaryKeyFieldName), column) {
 		return nil, sql3.NewErrInternalf("non _id column required")
 	}
 	return &PlanOpPQLDistinctScan{

--- a/sql3/planner/systemobjects.go
+++ b/sql3/planner/systemobjects.go
@@ -128,7 +128,7 @@ func (p *ExecutionPlanner) getViewByName(ctx context.Context, name string) (*vie
 		tableName: "fb_views",
 		columns:   cols,
 		predicate: newBinOpPlanExpression(
-			newQualifiedRefPlanExpression("fb_views", "_id", 0, parser.NewDataTypeString()),
+			newQualifiedRefPlanExpression("fb_views", string(dax.PrimaryKeyFieldName), 0, parser.NewDataTypeString()),
 			parser.EQ,
 			newStringLiteralPlanExpression(name),
 			parser.NewDataTypeBool(),
@@ -163,7 +163,7 @@ func (p *ExecutionPlanner) insertView(ctx context.Context, view *viewSystemObjec
 		planner:   p,
 		tableName: "fb_views",
 		targetColumns: []*qualifiedRefPlanExpression{
-			newQualifiedRefPlanExpression("fb_views", "_id", 0, parser.NewDataTypeString()),
+			newQualifiedRefPlanExpression("fb_views", string(dax.PrimaryKeyFieldName), 0, parser.NewDataTypeString()),
 			newQualifiedRefPlanExpression("fb_views", "name", 0, parser.NewDataTypeString()),
 			newQualifiedRefPlanExpression("fb_views", "statement", 0, parser.NewDataTypeString()),
 			newQualifiedRefPlanExpression("fb_views", "owner", 0, parser.NewDataTypeString()),
@@ -202,7 +202,7 @@ func (p *ExecutionPlanner) updateView(ctx context.Context, view *viewSystemObjec
 		planner:   p,
 		tableName: "fb_views",
 		targetColumns: []*qualifiedRefPlanExpression{
-			newQualifiedRefPlanExpression("fb_views", "_id", 0, parser.NewDataTypeString()),
+			newQualifiedRefPlanExpression("fb_views", string(dax.PrimaryKeyFieldName), 0, parser.NewDataTypeString()),
 			newQualifiedRefPlanExpression("fb_views", "statement", 0, parser.NewDataTypeString()),
 			newQualifiedRefPlanExpression("fb_views", "updated_by", 0, parser.NewDataTypeString()),
 			newQualifiedRefPlanExpression("fb_views", "updated_at", 0, parser.NewDataTypeTimestamp()),
@@ -233,7 +233,7 @@ func (p *ExecutionPlanner) deleteView(ctx context.Context, viewName string) erro
 		planner:   p,
 		tableName: "fb_views",
 		filter: newBinOpPlanExpression(
-			newQualifiedRefPlanExpression("fb_views", "_id", 0, parser.NewDataTypeString()),
+			newQualifiedRefPlanExpression("fb_views", string(dax.PrimaryKeyFieldName), 0, parser.NewDataTypeString()),
 			parser.EQ,
 			newStringLiteralPlanExpression(viewName),
 			parser.NewDataTypeBool(),

--- a/sql3/test/defs/defs.go
+++ b/sql3/test/defs/defs.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/PaesslerAG/gval"
 	"github.com/PaesslerAG/jsonpath"
+	"github.com/featurebasedb/featurebase/v3/errors"
 )
 
 // TableTests is the list of tests which get run by TestSQL_Execute in
@@ -221,17 +222,17 @@ func operatorPresentAtPath(jplan []byte, path string, operator string) error {
 	v := interface{}(nil)
 	err := json.Unmarshal(jplan, &v)
 	if err != nil {
-		return err
+		return errors.Wrap(err, fmt.Sprintf("expected '%s' to be present", operator))
 	}
 
 	builder := gval.Full(jsonpath.PlaceholderExtension())
 	expr, err := builder.NewEvaluable(path)
 	if err != nil {
-		return err
+		return errors.Wrap(err, fmt.Sprintf("expected '%s' to be present", operator))
 	}
 	eval, err := expr(context.Background(), v)
 	if err != nil {
-		return err
+		return errors.Wrap(err, fmt.Sprintf("expected '%s' to be present", operator))
 	}
 	s, ok := eval.(string)
 	if ok && strings.EqualFold(s, operator) {


### PR DESCRIPTION
This PR alters the behavior of `count(*)` to not depend on the `_id` column until the optimizer is sure that the operation is going to end up in a `pql.Call` graph.

This PR also replaces relevant instances of `"_id"` with he appropriate constant.