### PR TITLE
add support for time quantum inserts with explicit timestamps (fb-1558)

### DIFF
--- a/sql3/errors.go
+++ b/sql3/errors.go
@@ -709,7 +709,7 @@ func NewErrInsertValueOutOfRange(line, col int, columnName string, rowNumber int
 
 func NewErrUnexpectedTimeQuantumTupleLength(line, col int, columnName string, rowNumber int, badValue []interface{}, length int) error {
 	return errors.New(
-		ErrInsertValueOutOfRange,
+		ErrUnexpectedTimeQuantumTupleLength,
 		fmt.Sprintf("[%d:%d] inserting value into column '%s', row %d, value '%v' out of range", line, col, columnName, rowNumber, badValue),
 	)
 }

--- a/sql3/errors.go
+++ b/sql3/errors.go
@@ -109,7 +109,8 @@ const (
 
 	// insert errors
 
-	ErrInsertValueOutOfRange errors.Code = "ErrInsertValueOutOfRange"
+	ErrInsertValueOutOfRange            errors.Code = "ErrInsertValueOutOfRange"
+	ErrUnexpectedTimeQuantumTupleLength errors.Code = "ErrUnexpectedTimeQuantumTupleLength"
 
 	// bulk insert errors
 
@@ -700,6 +701,13 @@ func NewErrCallParameterValueInvalid(line, col int, badParameterValue string, pa
 // insert
 
 func NewErrInsertValueOutOfRange(line, col int, columnName string, rowNumber int, badValue interface{}) error {
+	return errors.New(
+		ErrInsertValueOutOfRange,
+		fmt.Sprintf("[%d:%d] inserting value into column '%s', row %d, value '%v' out of range", line, col, columnName, rowNumber, badValue),
+	)
+}
+
+func NewErrUnexpectedTimeQuantumTupleLength(line, col int, columnName string, rowNumber int, badValue []interface{}, length int) error {
 	return errors.New(
 		ErrInsertValueOutOfRange,
 		fmt.Sprintf("[%d:%d] inserting value into column '%s', row %d, value '%v' out of range", line, col, columnName, rowNumber, badValue),

--- a/sql3/planner/expression.go
+++ b/sql3/planner/expression.go
@@ -41,6 +41,14 @@ func coerceValue(sourceType parser.ExprDataType, targetType parser.ExprDataType,
 				return nil, sql3.NewErrInternalf("unexpected value type '%T'", value)
 			}
 			return pql.NewDecimal(val*int64(math.Pow(10, float64(t.Scale))), t.Scale), nil
+
+		case *parser.DataTypeTimestamp:
+			val, ok := value.(int64)
+			if !ok {
+				return nil, sql3.NewErrInternalf("unexpected value type '%T'", value)
+			}
+			tm := time.Unix(val, 0).UTC()
+			return tm, nil
 		}
 
 	case *parser.DataTypeID:
@@ -57,6 +65,14 @@ func coerceValue(sourceType parser.ExprDataType, targetType parser.ExprDataType,
 				return nil, sql3.NewErrInternalf("unexpected value type '%T'", value)
 			}
 			return pql.NewDecimal(int64(val)*int64(math.Pow(10, float64(t.Scale))), t.Scale), nil
+
+		case *parser.DataTypeTimestamp:
+			val, ok := value.(int64)
+			if !ok {
+				return nil, sql3.NewErrInternalf("unexpected value type '%T'", value)
+			}
+			tm := time.Unix(val, 0).UTC()
+			return tm, nil
 		}
 
 	case *parser.DataTypeDecimal:
@@ -2435,34 +2451,15 @@ func newExprTupleLiteralPlanExpression(members []types.PlanExpression, dataType 
 }
 
 func (n *exprTupleLiteralPlanExpression) Evaluate(currentRow []interface{}) (interface{}, error) {
-	timestampEval, err := n.members[0].Evaluate(currentRow)
-	if err != nil {
-		return nil, err
-	}
-
-	// if it is a string, do a coercion
-	if val, ok := timestampEval.(string); ok {
-		if tm, err := timestampFromString(val); err != nil {
-			return nil, sql3.NewErrInvalidTypeCoercion(0, 0, val, n.members[0].Type().TypeDescription())
-		} else {
-			timestampEval = tm
+	result := make([]interface{}, len(n.members))
+	for i, m := range n.members {
+		v, err := m.Evaluate(currentRow)
+		if err != nil {
+			return nil, err
 		}
+		result[i] = v
 	}
-
-	setEval, err := n.members[1].Evaluate(currentRow)
-	if err != nil {
-		return nil, err
-	}
-
-	// nil if anything is nil
-	if timestampEval == nil || setEval == nil {
-		return nil, nil
-	}
-
-	return []interface{}{
-		timestampEval,
-		setEval,
-	}, nil
+	return result, nil
 }
 
 func (n *exprTupleLiteralPlanExpression) Type() parser.ExprDataType {

--- a/sql3/planner/expressiontypes.go
+++ b/sql3/planner/expressiontypes.go
@@ -290,12 +290,8 @@ func typesAreAssignmentCompatible(targetType parser.ExprDataType, sourceType par
 			if len(source.Members) != 2 {
 				return false
 			}
-			_, ok := source.Members[0].(*parser.DataTypeTimestamp)
-			if !ok {
-				_, ok = source.Members[0].(*parser.DataTypeString)
-				if !ok {
-					return false
-				}
+			if !typesAreAssignmentCompatible(parser.NewDataTypeTimestamp(), source.Members[0]) {
+				return false
 			}
 			_, ok = source.Members[1].(*parser.DataTypeStringSet)
 			if !ok {
@@ -324,12 +320,8 @@ func typesAreAssignmentCompatible(targetType parser.ExprDataType, sourceType par
 			if len(source.Members) != 2 {
 				return false
 			}
-			_, ok := source.Members[0].(*parser.DataTypeTimestamp)
-			if !ok {
-				_, ok = source.Members[0].(*parser.DataTypeString)
-				if !ok {
-					return false
-				}
+			if !typesAreAssignmentCompatible(parser.NewDataTypeTimestamp(), source.Members[0]) {
+				return false
 			}
 			_, ok = source.Members[1].(*parser.DataTypeIDSet)
 			if !ok {
@@ -353,6 +345,9 @@ func typesAreAssignmentCompatible(targetType parser.ExprDataType, sourceType par
 	case *parser.DataTypeTimestamp:
 		switch sourceType.(type) {
 		case *parser.DataTypeTimestamp:
+			return true
+		case *parser.DataTypeInt:
+			//could be a int convertable to a date
 			return true
 		case *parser.DataTypeString:
 			//could be a string parseable as a date

--- a/sql3/test/defs/defs_date_functions.go
+++ b/sql3/test/defs/defs_date_functions.go
@@ -30,12 +30,6 @@ var datePartTests = TableTest{
 		},
 		{
 			SQLs: sqls(
-				"select datepart('1', 2)",
-			),
-			ExpErr: "an expression of type 'int' cannot be passed to a parameter of type 'timestamp'",
-		},
-		{
-			SQLs: sqls(
 				"select datepart('1', current_timestamp)",
 			),
 			ExpErr: "invalid value '1' for parameter 'interval'",

--- a/sql3/test/defs/defs_timequantum.go
+++ b/sql3/test/defs/defs_timequantum.go
@@ -7,13 +7,36 @@ var timeQuantumInsertTest = TableTest{
 		srcHdrs(
 			srcHdr("_id", fldTypeID),
 			srcHdr("i1", fldTypeInt, "min 0", "max 1000"),
+			srcHdr("ss1", fldTypeStringSet, "timequantum 'YMD'"),
 			srcHdr("ids1", fldTypeIDSet, "timequantum 'YMD'"),
 		),
 	),
 	SQLTests: []SQLTest{
 		{
 			SQLs: sqls(
-				"insert into time_quantum_insert (_id, i1, ids1) values (1, 1, [1])",
+				"insert into time_quantum_insert (_id, i1, ss1, ids1) values (1, 1, ['1'], [1])",
+			),
+			ExpHdrs: hdrs(),
+			ExpRows: rows(),
+			Compare: CompareExactUnordered,
+		},
+		{
+			SQLs: sqls(
+				"insert into time_quantum_insert (_id, i1, ss1, ids1) values (1, 1, {['1']}, {[1]})",
+			),
+			ExpErr: "an expression of type 'tuple(stringset)' cannot be assigned to type 'stringset'",
+		},
+		{
+			SQLs: sqls(
+				"insert into time_quantum_insert (_id, i1, ss1, ids1) values (1, 1, {1676649734, ['1']}, {1676649734, [1]})",
+			),
+			ExpHdrs: hdrs(),
+			ExpRows: rows(),
+			Compare: CompareExactUnordered,
+		},
+		{
+			SQLs: sqls(
+				"insert into time_quantum_insert (_id, i1, ss1, ids1) values (1, 1, {'2022-01-01T00:00:00Z', ['1']}, {'2022-01-01T00:00:00Z', [1]})",
 			),
 			ExpHdrs: hdrs(),
 			ExpRows: rows(),


### PR DESCRIPTION
This PR adds support for time quantum inserts with explicit timestamps.

Oh, and tests.