### PR TITLE
SUP-297

### DIFF
--- a/http_handler.go
+++ b/http_handler.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"math"
 	"mime"
 	"net"
@@ -4318,4 +4319,8 @@ func (h *Handler) handlePostDataframe(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), 500)
 		return
 	}
+}
+
+func (h *Handler) DiscardHTTPServerLogs() {
+	h.server.ErrorLog = log.New(io.Discard, "", 0)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -721,6 +721,16 @@ func (m *Command) setupServer() error {
 		return errors.Wrap(err, "new handler")
 	}
 
+	if err != nil {
+		return errors.Wrap(err, "new handler")
+	}
+	// ignore http server logs unless verbose logging in enabled
+	if uri.Scheme == "https" {
+		if !m.Config.Verbose {
+			hndlr.DiscardHTTPServerLogs()
+		}
+	}
+
 	m.httpHandler = hndlr
 	m.Handler = hndlr
 


### PR DESCRIPTION
When TLS is enabled, the net/http package logging can be much too verbose. This package will log to the featurebase logs only when verbose is enabled.