### PR TITLE
Separate the featurebase and fbsql make build targets

### DIFF
--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -161,6 +161,10 @@ build featurebase:
     - GOOS="linux" GOARCH="arm64" make build FLAGS="-o featurebase_linux_arm64"
     - GOOS="darwin" GOARCH="amd64" make build FLAGS="-o featurebase_darwin_amd64"
     - GOOS="darwin" GOARCH="arm64" make build FLAGS="-o featurebase_darwin_arm64"
+    - GOOS="linux" GOARCH="amd64" make build-fbsql FLAGS="-o fbsql_linux_amd64"
+    - GOOS="linux" GOARCH="arm64" make build-fbsql FLAGS="-o fbsql_linux_arm64"
+    - GOOS="darwin" GOARCH="amd64" make build-fbsql FLAGS="-o fbsql_darwin_amd64"
+    - GOOS="darwin" GOARCH="arm64" make build-fbsql FLAGS="-o fbsql_darwin_arm64"
   artifacts:
     paths:
       - featurebase_linux_amd64

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ build-fbsql:
 
 package:
 	GOOS=$(GOOS) GOARCH=$(GOARCH) $(MAKE) build
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(MAKE) build-fbsql
 	GOARCH=$(GOARCH) VERSION=$(VERSION) nfpm package --packager deb --target featurebase.$(VERSION).$(GOARCH).deb
 	GOARCH=$(GOARCH) VERSION=$(VERSION) nfpm package --packager rpm --target featurebase.$(VERSION).$(GOARCH).rpm
 

--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,12 @@ cover:
 cover-viz: cover
 	$(GO) tool cover -html=build/coverage.out
 
-# Compile Pilosa
+# Build featurebase
 build:
 	$(GO) build -tags='$(BUILD_TAGS)' -ldflags $(LDFLAGS) $(FLAGS) ./cmd/featurebase
+
+# Build fbsql
+build-fbsql:
 	$(GO) build -tags='$(BUILD_TAGS)' -ldflags $(LDFLAGS) $(FLAGS) ./cmd/fbsql
 
 


### PR DESCRIPTION
Using the same build target was problematic because they shared the same flags. Since the `-o` output flag was used, the fbsql binary was overwriting the featurebase binary.