### PR TITLE
fb-2013 remove sql endpoint feature flag.

### DIFF
--- a/ctl/server.go
+++ b/ctl/server.go
@@ -112,8 +112,6 @@ func serverFlagSet(srv *server.Config, prefix string) *pflag.FlagSet {
 	// RBF specific flags. See pilosa/rbf/cfg/cfg.go for definitions.
 	srv.RBFConfig.DefineFlags(flags, prefix)
 
-	flags.BoolVar(&srv.SQL.EndpointEnabled, pre("sql.endpoint-enabled"), srv.SQL.EndpointEnabled, "Enable FeatureBase SQL /sql endpoint (default false)")
-
 	flags.DurationVar(&srv.CheckInInterval, pre("check-in-interval"), srv.CheckInInterval, "Interval between check-ins to the Controller")
 
 	// Future flags.

--- a/http_handler.go
+++ b/http_handler.go
@@ -91,10 +91,6 @@ type Handler struct {
 	auth *authn.Auth
 
 	permissions *authz.GroupPermissions
-
-	// sqlEnabled is serving as a feature flag for turning on/off the /sql
-	// endpoint.
-	sqlEnabled bool
 }
 
 // externalPrefixFlag denotes endpoints that are intended to be exposed to clients.
@@ -223,14 +219,6 @@ func OptHandlerListener(ln net.Listener, url string) handlerOption {
 func OptHandlerCloseTimeout(d time.Duration) handlerOption {
 	return func(h *Handler) error {
 		h.closeTimeout = d
-		return nil
-	}
-}
-
-// OptHandlerSQLEnabled enables the /sql endpoint.
-func OptHandlerSQLEnabled(v bool) handlerOption {
-	return func(h *Handler) error {
-		h.sqlEnabled = v
 		return nil
 	}
 }
@@ -544,10 +532,7 @@ func newRouter(handler *Handler) http.Handler {
 	router.HandleFunc("/transactions", handler.chkAuthZ(handler.handleGetTransactions, authz.Read)).Methods("GET").Name("GetTransactions")
 	router.HandleFunc("/queries", handler.chkAuthZ(handler.handleGetActiveQueries, authz.Admin)).Methods("GET").Name("GetActiveQueries")
 
-	// enable this endpoint based on config
-	if handler.sqlEnabled {
-		router.HandleFunc("/sql", handler.chkAuthZ(handler.handlePostSQL, authz.Admin)).Methods("POST").Name("PostSQL")
-	}
+	router.HandleFunc("/sql", handler.chkAuthZ(handler.handlePostSQL, authz.Admin)).Methods("POST").Name("PostSQL")
 	// internal endpoint
 	router.HandleFunc("/sql-exec-graph", handler.chkAuthZ(handler.handlePostSQLPlanOperator, authz.Admin)).Methods("POST").Name("PostSQLPlanOperator")
 

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -549,7 +549,6 @@ func TestGetViewAndDelete(t *testing.T) {
 // the expected json tags.
 func TestHandlerSQL(t *testing.T) {
 	cfg := server.NewConfig()
-	cfg.SQL.EndpointEnabled = true
 	c := test.MustRunCluster(t, 1, []server.CommandOption{
 		server.OptCommandConfig(cfg),
 	})

--- a/server/config.go
+++ b/server/config.go
@@ -213,11 +213,6 @@ type Config struct {
 		MutexFraction int `toml:"mutex-fraction"`
 	} `toml:"profile"`
 
-	SQL struct {
-		// EndpointEnabled enables the /sql endpoint.
-		EndpointEnabled bool `toml:"endpoint-enabled"`
-	} `toml:"sql"`
-
 	// CheckInTimeout is the amount of time between compute node check-ins to
 	// Controller.
 	CheckInInterval time.Duration `toml:"check-in-interval"`
@@ -416,8 +411,6 @@ func NewConfig() *Config {
 
 	c.Profile.BlockRate = 10000000 // 1 sample per 10 ms
 	c.Profile.MutexFraction = 100  // 1% sampling
-
-	c.SQL.EndpointEnabled = false
 
 	c.Etcd.AClientURL = ""
 	c.Etcd.LClientURL = "http://localhost:10301"

--- a/server/server.go
+++ b/server/server.go
@@ -132,7 +132,6 @@ func OptCommandConfig(config *Config) CommandOption {
 			c.Config.Auth = config.Auth
 			c.Config.TLS = config.TLS
 			c.Config.ControllerAddress = config.ControllerAddress
-			c.Config.SQL.EndpointEnabled = config.SQL.EndpointEnabled
 			return nil
 		}
 		c.Config = config
@@ -717,7 +716,6 @@ func (m *Command) setupServer() error {
 		pilosa.OptHandlerAuthZ(&p),
 		pilosa.OptHandlerSerializer(proto.Serializer{}),
 		pilosa.OptHandlerRoaringSerializer(proto.RoaringSerializer),
-		pilosa.OptHandlerSQLEnabled(m.Config.SQL.EndpointEnabled),
 	)
 	if err != nil {
 		return errors.Wrap(err, "new handler")


### PR DESCRIPTION
Default config will have the sq.endpoint-enabled set to true. Server instances started with default config will accept SQL requests. 