### PR TITLE
This changes the server sub-command to ignore unknown flag. Fixes FB-2019

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -47,6 +47,9 @@ func newServeCmd(stderr io.Writer) *cobra.Command {
 	serveCmd := &cobra.Command{
 		Use:   "server",
 		Short: "Run FeatureBase.",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
 		Long: `featurebase server runs FeatureBase.
 
 It will load existing data from the configured

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/featurebasedb/featurebase/v3/ctl"
@@ -47,18 +48,16 @@ func newServeCmd(stderr io.Writer) *cobra.Command {
 	serveCmd := &cobra.Command{
 		Use:   "server",
 		Short: "Run FeatureBase.",
-		FParseErrWhitelist: cobra.FParseErrWhitelist{
-			UnknownFlags: true,
-		},
 		Long: `featurebase server runs FeatureBase.
-
 It will load existing data from the configured
 directory and start listening for client connections
 on the configured port.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Start & run the server.
+
 			if err := Server.Start(); err != nil {
-				return considerUsageError(cmd, errors.Wrap(err, "running server"))
+				fmt.Println("Test!!")
+				// return considerUsageError(cmd, errors.Wrap(err, "running server"))
 			}
 
 			return errors.Wrap(Server.Wait(), "waiting on Server")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/featurebasedb/featurebase/v3/ctl"
@@ -54,10 +53,8 @@ directory and start listening for client connections
 on the configured port.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Start & run the server.
-
 			if err := Server.Start(); err != nil {
-				fmt.Println("Test!!")
-				// return considerUsageError(cmd, errors.Wrap(err, "running server"))
+				return considerUsageError(cmd, errors.Wrap(err, "running server"))
 			}
 
 			return errors.Wrap(Server.Wait(), "waiting on Server")

--- a/ctl/server.go
+++ b/ctl/server.go
@@ -112,6 +112,10 @@ func serverFlagSet(srv *server.Config, prefix string) *pflag.FlagSet {
 	// RBF specific flags. See pilosa/rbf/cfg/cfg.go for definitions.
 	srv.RBFConfig.DefineFlags(flags, prefix)
 
+	pfalse := false
+	flags.BoolVar(&pfalse, pre("sql.endpoint-enabled"), false, "Enable FeatureBase SQL /sql endpoint (default false)")
+	flags.MarkDeprecated("sql.endpoint-enabled", "sql.endpoint-enabled is deprecated")
+
 	flags.DurationVar(&srv.CheckInInterval, pre("check-in-interval"), srv.CheckInInterval, "Interval between check-ins to the Controller")
 
 	// Future flags.


### PR DESCRIPTION
This uses the cobra library options to mark the sql3 flag as deprecated so the DB doesn't, ya know, explodey if someone tries to pass it in after we remove the flag.