### PR TITLE
Fb 1897

### DIFF
--- a/sql3/planner/expression.go
+++ b/sql3/planner/expression.go
@@ -1533,8 +1533,8 @@ func (n *callPlanExpression) Evaluate(currentRow []interface{}) (interface{}, er
 		return n.EvaluateSetContainsAny(currentRow)
 	case "SETCONTAINSALL":
 		return n.EvaluateSetContainsAll(currentRow)
-	case "DATEPART":
-		return n.EvaluateDatepart(currentRow)
+	case "DATETIMEPART":
+		return n.EvaluateDateTimePart(currentRow)
 	case "REVERSE":
 		return n.EvaluateReverse(currentRow)
 	case "UPPER":

--- a/sql3/planner/expressionanalyzercall.go
+++ b/sql3/planner/expressionanalyzercall.go
@@ -214,8 +214,8 @@ func (p *ExecutionPlanner) analyzeCallExpression(ctx context.Context, call *pars
 
 		call.ResultDataType = parser.NewDataTypeBool()
 
-	case "DATEPART":
-		return p.analyzeFunctionDatePart(call, scope)
+	case "DATETIMEPART":
+		return p.analyzeFunctionDateTimePart(call, scope)
 	case "REVERSE":
 		return p.analyseFunctionReverse(call, scope)
 	case "CHAR":

--- a/sql3/planner/inbuiltfunctionsdate.go
+++ b/sql3/planner/inbuiltfunctionsdate.go
@@ -23,7 +23,7 @@ const intervalMillisecond = "MS"
 const intervalMicrosecond = "US"
 const intervalNanosecond = "NS"
 
-func (p *ExecutionPlanner) analyzeFunctionDatePart(call *parser.Call, scope parser.Statement) (parser.Expr, error) {
+func (p *ExecutionPlanner) analyzeFunctionDateTimePart(call *parser.Call, scope parser.Statement) (parser.Expr, error) {
 
 	if len(call.Args) != 2 {
 		return nil, sql3.NewErrCallParameterCountMismatch(call.Rparen.Line, call.Rparen.Column, call.Name.Name, 2, len(call.Args))
@@ -144,7 +144,7 @@ func (p *ExecutionPlanner) analyzeFunctionDateTimeName(call *parser.Call, scope 
 	return call, nil
 }
 
-func (n *callPlanExpression) EvaluateDatepart(currentRow []interface{}) (interface{}, error) {
+func (n *callPlanExpression) EvaluateDateTimePart(currentRow []interface{}) (interface{}, error) {
 	intervalEval, err := n.args[0].Evaluate(currentRow)
 	if err != nil {
 		return nil, err

--- a/sql3/test/defs/defs.go
+++ b/sql3/test/defs/defs.go
@@ -45,7 +45,7 @@ var TableTests []TableTest = []TableTest{
 	setLiteralTests,
 	setFunctionTests,
 	setParameterTests,
-	datePartTests,
+	dateTimePartTests,
 	dateTimeNameTests,
 	toTimestampTests,
 	datetimeAddTests,

--- a/sql3/test/defs/defs_date_functions.go
+++ b/sql3/test/defs/defs_date_functions.go
@@ -5,11 +5,11 @@ import (
 	"time"
 )
 
-// datepart tests
-var datePartTests = TableTest{
+// datetimepart tests
+var dateTimePartTests = TableTest{
 
 	Table: tbl(
-		"dateparttests",
+		"datetimeparttests",
 		srcHdrs(
 			srcHdr("_id", fldTypeID),
 			srcHdr("a", fldTypeInt, "min 0", "max 1000"),
@@ -22,23 +22,23 @@ var datePartTests = TableTest{
 	),
 	SQLTests: []SQLTest{
 		{
-			name: "DatePartIncorrectParamsCount",
+			name: "DateTimePartIncorrectParamsCount",
 			SQLs: sqls(
-				"select datepart()",
+				"select datetimepart()",
 			),
 			ExpErr: "count of formal parameters (2) does not match count of actual parameters (0)",
 		},
 		{
-			name: "DatePartIntError",
+			name: "DateTimePartIntError",
 			SQLs: sqls(
-				"select datepart(1, 2)",
+				"select datetimepart(1, 2)",
 			),
 			ExpErr: "an expression of type 'int' cannot be passed to a parameter of type 'string'",
 		},
 		{
-			name: "DatePartInvalidParam",
+			name: "DateTimePartInvalidParam",
 			SQLs: sqls(
-				"select datepart('1', current_timestamp)",
+				"select datetimepart('1', current_timestamp)",
 			),
 			ExpErr: "invalid value '1' for parameter 'interval'",
 		},
@@ -71,9 +71,9 @@ var datePartTests = TableTest{
 			ExpErr: "invalid value 'x' for parameter 'timeunit'",
 		},
 		{
-			name: "DATEPARTYY",
+			name: "DATETIMEPARTYY",
 			SQLs: sqls(
-				"select _id, datepart('yy', ts) from dateparttests",
+				"select _id, datetimepart('yy', ts) from datetimeparttests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -85,9 +85,9 @@ var datePartTests = TableTest{
 			Compare: CompareExactUnordered,
 		},
 		{
-			name: "DATEPARTYD",
+			name: "DATETIMEPARTYD",
 			SQLs: sqls(
-				"select _id, datepart('yd', ts) from dateparttests",
+				"select _id, datetimepart('yd', ts) from datetimeparttests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -99,9 +99,9 @@ var datePartTests = TableTest{
 			Compare: CompareExactUnordered,
 		},
 		{
-			name: "DATEPARTM",
+			name: "DATETIMEPARTM",
 			SQLs: sqls(
-				"select _id, datepart('m', ts) from dateparttests",
+				"select _id, datetimepart('m', ts) from datetimeparttests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -113,9 +113,9 @@ var datePartTests = TableTest{
 			Compare: CompareExactUnordered,
 		},
 		{
-			name: "DATEPARTD",
+			name: "DATETIMEPARTD",
 			SQLs: sqls(
-				"select _id, datepart('d', ts) from dateparttests",
+				"select _id, datetimepart('d', ts) from datetimeparttests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -127,9 +127,9 @@ var datePartTests = TableTest{
 			Compare: CompareExactUnordered,
 		},
 		{
-			name: "DATEPARTW",
+			name: "DATETIMEPARTW",
 			SQLs: sqls(
-				"select _id, datepart('w', ts) from dateparttests",
+				"select _id, datetimepart('w', ts) from datetimeparttests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -141,9 +141,9 @@ var datePartTests = TableTest{
 			Compare: CompareExactUnordered,
 		},
 		{
-			name: "DATEPARTWK",
+			name: "DATETIMEPARTWK",
 			SQLs: sqls(
-				"select _id, datepart('wk', ts) from dateparttests",
+				"select _id, datetimepart('wk', ts) from datetimeparttests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -155,9 +155,9 @@ var datePartTests = TableTest{
 			Compare: CompareExactUnordered,
 		},
 		{
-			name: "DATEPARTHH",
+			name: "DATETIMEPARTHH",
 			SQLs: sqls(
-				"select _id, datepart('hh', ts) from dateparttests",
+				"select _id, datetimepart('hh', ts) from datetimeparttests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -169,9 +169,9 @@ var datePartTests = TableTest{
 			Compare: CompareExactUnordered,
 		},
 		{
-			name: "DatePartMI",
+			name: "DateTimePartMI",
 			SQLs: sqls(
-				"select _id, datepart('mi', ts) from dateparttests",
+				"select _id, datetimepart('mi', ts) from datetimeparttests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -183,9 +183,9 @@ var datePartTests = TableTest{
 			Compare: CompareExactUnordered,
 		},
 		{
-			name: "DatePartS",
+			name: "DateTimePartS",
 			SQLs: sqls(
-				"select _id, datepart('s', ts) from dateparttests",
+				"select _id, datetimepart('s', ts) from datetimeparttests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -197,9 +197,9 @@ var datePartTests = TableTest{
 			Compare: CompareExactUnordered,
 		},
 		{
-			name: "DatePartMS",
+			name: "DateTimePartMS",
 			SQLs: sqls(
-				"select _id, datepart('ms', ts) from dateparttests",
+				"select _id, datetimepart('ms', ts) from datetimeparttests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -211,8 +211,9 @@ var datePartTests = TableTest{
 			Compare: CompareExactUnordered,
 		},
 		{
+			name: "DateTimePartUS",
 			SQLs: sqls(
-				"select _id, datepart('us', ts) from dateparttests",
+				"select _id, datetimepart('us', ts) from datetimeparttests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -224,9 +225,9 @@ var datePartTests = TableTest{
 			Compare: CompareExactUnordered,
 		},
 		{
-			name: "DatePartNS",
+			name: "DateTimePartNS",
 			SQLs: sqls(
-				"select _id, datepart('ns', ts) from dateparttests",
+				"select _id, datetimepart('ns', ts) from datetimeparttests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -238,10 +239,10 @@ var datePartTests = TableTest{
 			Compare: CompareExactUnordered,
 		},
 		{
-			//test datepart(timestamp, part) for implicit conversion of integer value passed as argument to timestamp param
-			name: "DatePartImplicitIntConversion",
+			//test datetimepart(timestamp, part) for implicit conversion of integer value passed as argument to timestamp param
+			name: "DateTimePartImplicitIntConversion",
 			SQLs: sqls(
-				"select datepart('yy', 0) as \"yy\", datepart('m', 0) as \"m\", datepart('d', 0) as \"d\"",
+				"select datetimepart('yy', 0) as \"yy\", datetimepart('m', 0) as \"m\", datetimepart('d', 0) as \"d\"",
 			),
 			ExpHdrs: hdrs(
 				hdr("yy", fldTypeInt),
@@ -382,7 +383,7 @@ var dateTimeNameTests = TableTest{
 		// if this works then the other parts converted to strings of digits should also work
 		{
 			SQLs: sqls(
-				"select _id, datetimename('yy', ts) from dateparttests",
+				"select _id, datetimename('yy', ts) from datetimenametests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -396,7 +397,7 @@ var dateTimeNameTests = TableTest{
 		//check to make sure it gets a month name correctly
 		{
 			SQLs: sqls(
-				"select _id, datetimename('m', ts) from dateparttests",
+				"select _id, datetimename('m', ts) from datetimenametests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -410,7 +411,7 @@ var dateTimeNameTests = TableTest{
 		// check to make sure it gets a day of the week correctly
 		{
 			SQLs: sqls(
-				"select _id, datetimename('w', ts) from dateparttests",
+				"select _id, datetimename('w', ts) from datetimenametests",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -477,7 +478,7 @@ var datetimeAddTests = TableTest{
 		//Test datetimeadd() for all possible time units
 		{
 			SQLs: sqls(
-				"select _id, datepart('YY',datetimeadd('YY', 1, ts)) from datetimeadd",
+				"select _id, datetimepart('YY',datetimeadd('YY', 1, ts)) from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -490,7 +491,7 @@ var datetimeAddTests = TableTest{
 		},
 		{
 			SQLs: sqls(
-				"select _id, datepart('M',datetimeadd('M', 1, ts)) from datetimeadd",
+				"select _id, datetimepart('M',datetimeadd('M', 1, ts)) from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -503,7 +504,7 @@ var datetimeAddTests = TableTest{
 		},
 		{
 			SQLs: sqls(
-				"select _id, datepart('D',datetimeadd('D', 1, ts)) from datetimeadd",
+				"select _id, datetimepart('D',datetimeadd('D', 1, ts)) from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -516,7 +517,7 @@ var datetimeAddTests = TableTest{
 		},
 		{
 			SQLs: sqls(
-				"select _id, datepart('HH',datetimeadd('HH', 1, ts)) from datetimeadd",
+				"select _id, datetimepart('HH',datetimeadd('HH', 1, ts)) from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -529,7 +530,7 @@ var datetimeAddTests = TableTest{
 		},
 		{
 			SQLs: sqls(
-				"select _id, datepart('MI',datetimeadd('MI', 1, ts)) from datetimeadd",
+				"select _id, datetimepart('MI',datetimeadd('MI', 1, ts)) from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -542,7 +543,7 @@ var datetimeAddTests = TableTest{
 		},
 		{
 			SQLs: sqls(
-				"select _id, datepart('S',datetimeadd('S', 1, ts)) from datetimeadd",
+				"select _id, datetimepart('S',datetimeadd('S', 1, ts)) from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -555,7 +556,7 @@ var datetimeAddTests = TableTest{
 		},
 		{
 			SQLs: sqls(
-				"select _id, datepart('MS',datetimeadd('MS', 1, ts)) from datetimeadd",
+				"select _id, datetimepart('MS',datetimeadd('MS', 1, ts)) from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -568,7 +569,7 @@ var datetimeAddTests = TableTest{
 		},
 		{
 			SQLs: sqls(
-				"select _id, datepart('US',datetimeadd('US', 1, ts)) from datetimeadd",
+				"select _id, datetimepart('US',datetimeadd('US', 1, ts)) from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -581,7 +582,7 @@ var datetimeAddTests = TableTest{
 		},
 		{
 			SQLs: sqls(
-				"select _id, datepart('NS',datetimeadd('NS', 1, ts)) from datetimeadd",
+				"select _id, datetimepart('NS',datetimeadd('NS', 1, ts)) from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -595,7 +596,7 @@ var datetimeAddTests = TableTest{
 		//test datetimeadd() for subtraction
 		{
 			SQLs: sqls(
-				"select _id, datepart('YY',datetimeadd('YY', -1, ts)) from datetimeadd",
+				"select _id, datetimepart('YY',datetimeadd('YY', -1, ts)) from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -609,7 +610,7 @@ var datetimeAddTests = TableTest{
 		//test datetimeadd() for transition
 		{
 			SQLs: sqls(
-				"select _id, datepart('NS',datetimeadd('NS', 700, ts)) as a, datepart('US',datetimeadd('NS', 700, ts)) as b from datetimeadd",
+				"select _id, datetimepart('NS',datetimeadd('NS', 700, ts)) as a, datetimepart('US',datetimeadd('NS', 700, ts)) as b from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -624,7 +625,7 @@ var datetimeAddTests = TableTest{
 		//test datetimeadd() for literals
 		{
 			SQLs: sqls(
-				"select _id, datepart('YY',datetimeadd('YY', 1, 0)) from datetimeadd",
+				"select _id, datetimepart('YY',datetimeadd('YY', 1, 0)) from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),
@@ -637,7 +638,7 @@ var datetimeAddTests = TableTest{
 		},
 		{
 			SQLs: sqls(
-				"select _id, datepart('YY',datetimeadd('YY', 1, '2023-03-03T00:00:00Z')) from datetimeadd",
+				"select _id, datetimepart('YY',datetimeadd('YY', 1, '2023-03-03T00:00:00Z')) from datetimeadd",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),

--- a/sql3/test/defs/defs_timestamp_literals.go
+++ b/sql3/test/defs/defs_timestamp_literals.go
@@ -54,7 +54,7 @@ var timestampLiterals = TableTest{
 		{
 			//compare test is done only for integer test cases (_id in (3,4), because only for these cases we have a determinate year(1970, 1969) to look for.
 			SQLs: sqls(
-				"select _id, datepart('yy', ts) as \"yy\" from testtimestampliterals where _id in (3,4)",
+				"select _id, datetimepart('yy', ts) as \"yy\" from testtimestampliterals where _id in (3,4)",
 			),
 			ExpHdrs: hdrs(
 				hdr("_id", fldTypeID),


### PR DESCRIPTION
Change datepart function to datetimepart 
FB-1897 
The specs for the datetimepart function are, as far as i can tell, identical to the existing datepart function. Per Pat, replaced the datepart function with datetimepart rather than just adding datetimepart as an alias. Made sure existing tests that were using datepart got switched over.