### PR TITLE
handle empty avg agg

### DIFF
--- a/sql3/planner/oppqlaggregate.go
+++ b/sql3/planner/oppqlaggregate.go
@@ -269,7 +269,13 @@ func (i *pqlAggregateRowIter) Next(ctx context.Context) (types.Row, error) {
 			case *parser.DataTypeDecimal:
 				_, isAvg := i.aggregate.(*avgPlanExpression)
 				if isAvg {
-					if actualResult.DecimalVal == nil {
+					if actualResult.Count == 0 {
+						daverage, err := pql.FromFloat64WithScale(float64(0), int(t.Scale))
+						if err != nil {
+							return nil, err
+						}
+						i.resultValue = daverage
+					} else if actualResult.DecimalVal == nil {
 						average := float64(actualResult.Val) / float64(actualResult.Count)
 						daverage, err := pql.FromFloat64WithScale(average, int(t.Scale))
 						if err != nil {

--- a/sql3/planner/oppqlaggregate.go
+++ b/sql3/planner/oppqlaggregate.go
@@ -270,11 +270,7 @@ func (i *pqlAggregateRowIter) Next(ctx context.Context) (types.Row, error) {
 				_, isAvg := i.aggregate.(*avgPlanExpression)
 				if isAvg {
 					if actualResult.Count == 0 {
-						daverage, err := pql.FromFloat64WithScale(float64(0), int(t.Scale))
-						if err != nil {
-							return nil, err
-						}
-						i.resultValue = daverage
+						i.resultValue = nil
 					} else if actualResult.DecimalVal == nil {
 						average := float64(actualResult.Val) / float64(actualResult.Count)
 						daverage, err := pql.FromFloat64WithScale(average, int(t.Scale))

--- a/sql3/test/defs/defs_aggregate.go
+++ b/sql3/test/defs/defs_aggregate.go
@@ -406,7 +406,7 @@ var avgTests = TableTest{
 				}),
 			),
 			ExpRows: rows(
-				row(pql.NewDecimal(0, 4)),
+				row(nil),
 			),
 			Compare: CompareExactUnordered,
 		},
@@ -422,7 +422,7 @@ var avgTests = TableTest{
 				}),
 			),
 			ExpRows: rows(
-				row(pql.NewDecimal(0, 4)),
+				row(nil),
 			),
 			Compare: CompareExactUnordered,
 		},

--- a/sql3/test/defs/defs_aggregate.go
+++ b/sql3/test/defs/defs_aggregate.go
@@ -394,6 +394,38 @@ var avgTests = TableTest{
 			),
 			Compare: CompareExactUnordered,
 		},
+		{
+			SQLs: sqls(
+				"SELECT avg(i1) AS avg_rows FROM avg_test WHERE i1 > 100",
+			),
+			ExpHdrs: hdrs(
+				hdr("avg_rows", featurebase.WireQueryField{
+					Type:     dax.BaseTypeDecimal + "(4)",
+					BaseType: dax.BaseTypeDecimal,
+					TypeInfo: map[string]interface{}{"scale": int64(4)},
+				}),
+			),
+			ExpRows: rows(
+				row(pql.NewDecimal(0, 4)),
+			),
+			Compare: CompareExactUnordered,
+		},
+		{
+			SQLs: sqls(
+				"SELECT avg(d1) AS avg_rows FROM avg_test WHERE d1 > 100.0",
+			),
+			ExpHdrs: hdrs(
+				hdr("avg_rows", featurebase.WireQueryField{
+					Type:     dax.BaseTypeDecimal + "(4)",
+					BaseType: dax.BaseTypeDecimal,
+					TypeInfo: map[string]interface{}{"scale": int64(4)},
+				}),
+			),
+			ExpRows: rows(
+				row(pql.NewDecimal(0, 4)),
+			),
+			Compare: CompareExactUnordered,
+		},
 	},
 }
 


### PR DESCRIPTION
AVG() returns null (as opposed to a very large magnitude value) when no records are returned by the WHERE filter.