### PR TITLE
Add CSV support to fbsql

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -393,7 +393,7 @@ func (cmd *Command) executeAndWriteQuery(qry query) error {
 		}
 		return errors.Wrap(err, "making query")
 	}
-	if err := writeTable(queryResponse, cmd.writeOptions, cmd.output, cmd.stdout, cmd.stderr); err != nil {
+	if err := writeOutput(queryResponse, cmd.writeOptions, cmd.output, cmd.stdout, cmd.stderr); err != nil {
 		return errors.Wrap(err, "writing out response")
 	}
 

--- a/cli/cli_integration_test.go
+++ b/cli/cli_integration_test.go
@@ -69,6 +69,7 @@ func TestCLIIntegration(t *testing.T) {
 			"meta_file",
 			"meta_pset_border",
 			"meta_pset_expanded",
+			"meta_pset_format_csv",
 			"meta_pset_tuples_only",
 			"meta_include",
 			"meta_output",

--- a/cli/testdata/meta_pset_format_csv
+++ b/cli/testdata/meta_pset_format_csv
@@ -1,0 +1,47 @@
+SEND:\pset format csv
+EXPECT:Output format is csv.
+
+SEND:SELECT * FROM users;
+EXPECT:_id,name,age
+EXPECT:1,Anne,38
+EXPECT:2,Bill,23
+EXPECT:3,Cindy,64
+
+// Exclude headers.
+SEND:\t on
+EXPECT:Tuples only is on.
+
+SEND:SELECT * FROM users;
+EXPECT:1,Anne,38
+EXPECT:2,Bill,23
+EXPECT:3,Cindy,64
+
+// Reset headers.
+SEND:\t off
+EXPECT:Tuples only is off.
+
+// Set expanded to on.
+SEND:\x on
+EXPECT:Expanded display is on.
+
+SEND:SELECT * FROM users;
+EXPECT:_id,1
+EXPECT:name,Anne
+EXPECT:age,38
+EXPECT:_id,2
+EXPECT:name,Bill
+EXPECT:age,23
+EXPECT:_id,3
+EXPECT:name,Cindy
+EXPECT:age,64
+
+// Set expanded back to off.
+SEND:\x off
+EXPECT:Expanded display is off.
+
+// Set format back to aligned as we started.
+SEND:\pset format aligned
+EXPECT:Output format is aligned.
+
+SEND:\pset format invalid
+EXPECT:executing meta command: \pset: allowed formats are aligned, csv

--- a/cli/testdata/meta_timing
+++ b/cli/testdata/meta_timing
@@ -19,7 +19,7 @@ SEND:\timing on extra
 EXPECT:executing meta command: meta command 'timing' takes zero or one argument
 
 
-SEND:SELECT * from users;
+SEND:SELECT * FROM users;
 EXPECT:+-----+-------+-----+
 EXPECT:| _id | name  | age |
 EXPECT:+-----+-------+-----+
@@ -35,7 +35,7 @@ SEND:\timing off
 EXPECT:Timing is off.
 
 // Ensure we don't get timing.
-SEND:SELECT * from users;
+SEND:SELECT * FROM users;
 EXPECT:+-----+-------+-----+
 EXPECT:| _id | name  | age |
 EXPECT:+-----+-------+-----+

--- a/cli/testdata/setup
+++ b/cli/testdata/setup
@@ -46,5 +46,6 @@ EXPECT:Border style is 2.
 SEND:\pset
 EXPECT:border      2
 EXPECT:expanded    off
+EXPECT:format      aligned
 EXPECT:location    UTC
 EXPECT:tuples_only off

--- a/cli/testdata/table
+++ b/cli/testdata/table
@@ -49,7 +49,7 @@ EXPECT:
 // running this creates the fb_views sytem table which has a description.
 // And it's annoying to mask out all of the description fields because we
 // don't know which row fb_views will fall into.
-SEND:SELECT * from users;
+SEND:SELECT * FROM users;
 EXPECT:+-----+-------+-----+
 EXPECT:| _id | name  | age |
 EXPECT:+-----+-------+-----+

--- a/cli/writer_test.go
+++ b/cli/writer_test.go
@@ -164,7 +164,7 @@ func TestWriter(t *testing.T) {
 				wOut := bytes.NewBuffer(make([]byte, 0, 100000))
 				wErr := bytes.NewBuffer(make([]byte, 0, 100000))
 
-				assert.NoError(t, writeTable(wqr, test.format, qOut, wOut, wErr))
+				assert.NoError(t, writeOutput(wqr, test.format, qOut, wOut, wErr))
 
 				assert.Equal(t, test.expQOut, qOut.String())
 				assert.Equal(t, test.expOut, wOut.String())

--- a/cli/writer_test.go
+++ b/cli/writer_test.go
@@ -58,6 +58,7 @@ func TestWriter(t *testing.T) {
 				format: &writeOptions{
 					border:     1,
 					expanded:   false,
+					format:     formatAligned,
 					timing:     true,
 					tuplesOnly: false,
 				},
@@ -77,6 +78,7 @@ func TestWriter(t *testing.T) {
 				format: &writeOptions{
 					border:     2,
 					expanded:   false,
+					format:     formatAligned,
 					timing:     false,
 					tuplesOnly: false,
 				},
@@ -98,6 +100,7 @@ func TestWriter(t *testing.T) {
 				format: &writeOptions{
 					border:     0,
 					expanded:   false,
+					format:     formatAligned,
 					timing:     false,
 					tuplesOnly: false,
 				},
@@ -117,6 +120,7 @@ func TestWriter(t *testing.T) {
 				format: &writeOptions{
 					border:     1,
 					expanded:   false,
+					format:     formatAligned,
 					timing:     false,
 					tuplesOnly: true,
 				},
@@ -134,6 +138,7 @@ func TestWriter(t *testing.T) {
 				format: &writeOptions{
 					border:     2,
 					expanded:   true,
+					format:     formatAligned,
 					timing:     false,
 					tuplesOnly: false,
 				},


### PR DESCRIPTION
This adds the `\pset format csv` meta command support.