### PR TITLE
Add SQL3 Tests added bulk insert tests

### DIFF
--- a/sql3/planner/opbulkinsert.go
+++ b/sql3/planner/opbulkinsert.go
@@ -266,13 +266,19 @@ func (i *bulkInsertSourceCSVRowIter) Next(ctx context.Context) (types.Row, error
 	rec, err := i.csvReader.Read()
 	if err == io.EOF {
 		return nil, types.ErrNoMoreRows
-	} else if err != nil {
-		pe, ok := err.(*csv.ParseError)
-		if ok {
-			return nil, sql3.NewErrReadingDatasource(0, 0, i.options.sourceData, fmt.Sprintf("csv parse error on line %d: %s", pe.Line, pe.Error()))
-		}
-		return nil, err
 	}
+	// err == csv.ParseError is impossible if LazyQuotes is true
+	// we should uncomment the code below if we ever dispable LazyQuotes
+	// so there is no need check for any other error
+	/*
+		else if err != nil {
+			pe, ok := err.(*csv.ParseError)
+			if ok {
+				return nil, sql3.NewErrReadingDatasource(0, 0, i.options.sourceData, fmt.Sprintf("csv parse error on line %d: %s", pe.Line, pe.Error()))
+			}
+			return nil, err
+		}
+	*/
 
 	// now we do the mapping to the output row
 	result := make([]interface{}, len(i.options.mapExpressions))

--- a/sql3/planner/opbulkinsert.go
+++ b/sql3/planner/opbulkinsert.go
@@ -319,8 +319,6 @@ func (i *bulkInsertSourceCSVRowIter) Next(ctx context.Context) (types.Row, error
 			if err != nil {
 				if tm, err := time.ParseInLocation(time.RFC3339Nano, evalValue, time.UTC); err == nil {
 					result[idx] = tm
-				} else if tm, err := time.ParseInLocation(time.RFC3339, evalValue, time.UTC); err == nil {
-					result[idx] = tm
 				} else if tm, err := time.ParseInLocation("2006-01-02", evalValue, time.UTC); err == nil {
 					result[idx] = tm
 				} else {
@@ -664,8 +662,6 @@ func (i *bulkInsertSourceNDJsonRowIter) Next(ctx context.Context) (types.Row, er
 
 					case string:
 						if tm, err := time.ParseInLocation(time.RFC3339Nano, v, time.UTC); err == nil {
-							result[idx] = tm
-						} else if tm, err := time.ParseInLocation(time.RFC3339, v, time.UTC); err == nil {
 							result[idx] = tm
 						} else if tm, err := time.ParseInLocation("2006-01-02", v, time.UTC); err == nil {
 							result[idx] = tm
@@ -1158,8 +1154,6 @@ func (i *bulkInsertSourceParquetRowIter) Next(ctx context.Context) (types.Row, e
 				result[idx] = time.Unix(intVal, 0).UTC()
 			} else if stringVal, ok := evalValue.(string); ok {
 				if tm, err := time.ParseInLocation(time.RFC3339Nano, stringVal, time.UTC); err == nil {
-					result[idx] = tm
-				} else if tm, err := time.ParseInLocation(time.RFC3339, stringVal, time.UTC); err == nil {
 					result[idx] = tm
 				} else if tm, err := time.ParseInLocation("2006-01-02", stringVal, time.UTC); err == nil {
 					result[idx] = tm


### PR DESCRIPTION
- [x] no coverage on input type 'URL' 
- [x] csv Parse Error not covered  
- [x] bulkInsertSourceNDJSonRowIter doesn't cover URL case 
- [x] bulkInsertNDJsonRowIter has no coverage for hitting batch size
- [x] bulkInsertLineRowIter case for batch size isn't getting covered 
- [x] bulkInsertSourceParquetRowIter not covering IDSet, StringSet, Bool, or time formats other than RFC3339Nano 
    *  fieldtype idset with a number 
    * fieldtype stringset with a string
   * fieldtype Bool with a bool(true/false)
- [x] no coverage for json.Number for DataTypeString 
- [x]  also no coverage in DataTypeTimestamp for json.Number, or time formats other than RFC3339Nano  
- [x]  time conversions for non-RFC3339Nano uncovered  