### PR TITLE
Increase golangci-lint timeout to 8 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           # version: v1.29
-          args: --timeout=5m
+          args: --timeout=8m
 
   validate:
     name: Code Checks


### PR DESCRIPTION
This is the time being used in our other CI pipeline.

The alternative to doing this is ripping out all of this code so that we're not running two CI pipelines...