### PR TITLE
SQL test backfilling

### DIFF
--- a/sql3/parser/ast.go
+++ b/sql3/parser/ast.go
@@ -299,6 +299,8 @@ func CloneExpr(expr Expr) Expr {
 		return expr.Clone()
 	case *StringLit:
 		return expr.Clone()
+	case *TupleLiteralExpr:
+		return expr.Clone()
 	case *UnaryExpr:
 		return expr.Clone()
 	case *Variable:
@@ -1795,6 +1797,7 @@ func (t *Type) String() string {
 type StringLit struct {
 	ValuePos Pos    // literal position
 	Value    string // literal value (without quotes)
+	IsBlob   bool   // are we a blob?
 }
 
 func (expr *StringLit) IsLiteral() bool { return true }
@@ -1831,7 +1834,11 @@ func (lit *StringLit) Clone() *StringLit {
 
 // String returns the string representation of the expression.
 func (lit *StringLit) String() string {
-	return `'` + strings.Replace(lit.Value, `'`, `''`, -1) + `'`
+	if lit.IsBlob {
+		return `x'` + strings.Replace(lit.Value, `'`, `''`, -1) + `'`
+	} else {
+		return `'` + strings.Replace(lit.Value, `'`, `''`, -1) + `'`
+	}
 }
 
 type IntegerLit struct {

--- a/sql3/parser/parser.go
+++ b/sql3/parser/parser.go
@@ -2419,22 +2419,7 @@ func (p *Parser) parseSource() (source Source, err error) {
 			return source, err
 		}
 
-		// Rewrite last source to nest next join on right side.
-		if lhs, ok := source.(*JoinClause); ok {
-			source = &JoinClause{
-				X:        lhs.X,
-				Operator: lhs.Operator,
-				Y: &JoinClause{
-					X:          lhs.Y,
-					Operator:   operator,
-					Y:          y,
-					Constraint: constraint,
-				},
-				Constraint: lhs.Constraint,
-			}
-		} else {
-			source = &JoinClause{X: source, Operator: operator, Y: y, Constraint: constraint}
-		}
+		source = &JoinClause{X: source, Operator: operator, Y: y, Constraint: constraint}
 	}
 }
 

--- a/sql3/parser/parser_test.go
+++ b/sql3/parser/parser_test.go
@@ -2055,38 +2055,36 @@ func TestParser_ParseStatement(t *testing.T) {
 				},
 			},
 		})
-		/*
-			// This one doesn't work right now because our stringify of this statement is wrong.
-			AssertParseStatement(t, `SELECT * FROM X INNER JOIN Y ON true INNER JOIN Z ON false`, &parser.SelectStatement{
-				Select: pos(0),
-				Columns: []*parser.ResultColumn{
-					{Star: pos(7)},
-				},
-				From: pos(9),
-				Source: &parser.JoinClause{
+		AssertParseStatement(t, `SELECT * FROM X INNER JOIN Y ON true INNER JOIN Z ON false`, &parser.SelectStatement{
+			Select: pos(0),
+			Columns: []*parser.ResultColumn{
+				{Star: pos(7)},
+			},
+			From: pos(9),
+			Source: &parser.JoinClause{
+				X: &parser.JoinClause{
 					X: &parser.QualifiedTableName{
 						Name: &parser.Ident{NamePos: pos(14), Name: "X"},
 					},
 					Operator: &parser.JoinOperator{Inner: pos(16), Join: pos(22)},
-					Y: &parser.JoinClause{
-						X: &parser.QualifiedTableName{
-							Name: &parser.Ident{NamePos: pos(27), Name: "Y"},
-						},
-						Operator: &parser.JoinOperator{Inner: pos(37), Join: pos(43)},
-						Y: &parser.QualifiedTableName{
-							Name: &parser.Ident{NamePos: pos(48), Name: "Z"},
-						},
-						Constraint: &parser.OnConstraint{
-							On: pos(50),
-							X:  &parser.BoolLit{ValuePos: pos(53), Value: false},
-						},
+					Y: &parser.QualifiedTableName{
+						Name: &parser.Ident{NamePos: pos(27), Name: "Y"},
 					},
 					Constraint: &parser.OnConstraint{
 						On: pos(29),
 						X:  &parser.BoolLit{ValuePos: pos(32), Value: true},
 					},
 				},
-			})*/
+				Operator: &parser.JoinOperator{Inner: pos(37), Join: pos(43)},
+				Y: &parser.QualifiedTableName{
+					Name: &parser.Ident{NamePos: pos(48), Name: "Z"},
+				},
+				Constraint: &parser.OnConstraint{
+					On: pos(50),
+					X:  &parser.BoolLit{ValuePos: pos(53), Value: false},
+				},
+			},
+		})
 		AssertParseStatement(t, `SELECT * FROM foo LEFT OUTER JOIN bar`, &parser.SelectStatement{
 			Select: pos(0),
 			Columns: []*parser.ResultColumn{

--- a/sql3/parser/scanner.go
+++ b/sql3/parser/scanner.go
@@ -335,20 +335,6 @@ func isAlpha(ch rune) bool {
 	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
 }
 
-func isHex(ch rune) bool {
-	return isDigit(ch) || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
-}
-
 func isUnquotedIdent(ch rune) bool {
 	return isAlpha(ch) || isDigit(ch) || ch == '_' || ch == '-'
-}
-
-// IsInteger returns true if s only contains digits.
-func IsInteger(s string) bool {
-	for _, ch := range s {
-		if !isDigit(ch) {
-			return false
-		}
-	}
-	return s != ""
 }

--- a/sql3/parser/scanner_test.go
+++ b/sql3/parser/scanner_test.go
@@ -41,6 +41,9 @@ func TestScanner_Scan(t *testing.T) {
 		t.Run("NoEndQuote", func(t *testing.T) {
 			AssertScan(t, `'unfinished`, parser.ILLEGAL, `'unfinished`)
 		})
+		t.Run("NoEndQuoteNL", func(t *testing.T) {
+			AssertScan(t, "'unfinished\n", parser.UNTERMSTRING, `'unfinished`)
+		})
 	})
 	t.Run("BLOB", func(t *testing.T) {
 		t.Run("LowerX", func(t *testing.T) {
@@ -51,6 +54,9 @@ func TestScanner_Scan(t *testing.T) {
 		})
 		t.Run("NoEndQuote", func(t *testing.T) {
 			AssertScan(t, `x'0123`, parser.ILLEGAL, `x'0123`)
+		})
+		t.Run("QuotedQuote", func(t *testing.T) {
+			AssertScan(t, `x'01''23'`, parser.BLOB, `01'23`)
 		})
 	})
 


### PR DESCRIPTION
This is actually two related sets of test cases in the parser/scanner stuff. (tickets 2073, 2074)

There's a couple of things in here which may want more careful attention. One is the previously-commented-out test case for a double inner join. It was commented out because stringizing the resulting data structure produced wildly different output, which broke the basic sanity checks. After studying this a bit, I've concluded that the code to "rewrite last source to nest next join on right side" logic was, in fact, precisely backwards -- we simply didn't want that code at all. Taking it out and expecting a data structure that makes sense also produces a data structure which stringizes back to the original query.

We add support for StringLit to know whether they came from blobs or not, so they can stringize to blobs again, so the round-trip testing works with them.

We add a test case that tests tuple assignment. I note that tuple assignment looks weird -- you have to use {} for the values, but () for the column names.

There's a number of still-unreached cases, but most of them are things where we check a token type with peek to decide to call a function, then that function asserts that the next token is that type. This shouldn't be capable of failing, but it's not a bad idea to have the extra checking there, I think?
