### PR TITLE
fbsql disconnect from database with `\c -`

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -487,7 +487,7 @@ func (cmd *Command) connectToDatabase(dbName string) error {
 		p = newNopPrinter()
 	}
 
-	// Providing a blank ("") or hyphen ("-") dnName is the equivalent of
+	// Providing a blank ("") or hyphen ("-") dbName is the equivalent of
 	// disconnecting from the current database. We support the hyphen option
 	// because calling the `\c` meta-command without an argument is how you
 	// print the current connection.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -487,7 +487,12 @@ func (cmd *Command) connectToDatabase(dbName string) error {
 		p = newNopPrinter()
 	}
 
-	if dbName == "" {
+	// Providing a blank ("") or hyphen ("-") dnName is the equivalent of
+	// disconnecting from the current database. We support the hyphen option
+	// because calling the `\c` meta-command without an argument is how you
+	// print the current connection.
+	switch dbName {
+	case "-", "":
 		cmd.databaseID = ""
 		cmd.databaseName = ""
 		p.Printf(cmd.connectionMessage())

--- a/cli/testdata/database
+++ b/cli/testdata/database
@@ -43,3 +43,11 @@ EXPECT:executing meta command: meta command 'connect' takes zero or one argument
 // Connect to a database.
 SEND:\c db1
 EXPECTCOMP:WithFormat:You are now connected to database "db1" ({uuid}).
+
+// Disconnect from the current database.
+SEND:\c -
+EXPECT:You are not connected to a database.
+
+// Connect to a database again.
+SEND:\c db1
+EXPECTCOMP:WithFormat:You are now connected to database "db1" ({uuid}).


### PR DESCRIPTION
This adds the ability to disconnect from the current database by passing a hyphen to the `\c` meta-command.