### PR TITLE
fbsql: add the `--csv` and `--pset` flags

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -387,6 +387,13 @@ func (cmd *Command) setupConfig() error {
 
 	cmd.historyPath = cmd.Config.HistoryPath
 
+	// Apply any pset flag arguments.
+	for _, pset := range cmd.Config.PSets {
+		if err := cmd.applyPSet(pset); err != nil {
+			return errors.Wrapf(err, "applying pset: %s", pset)
+		}
+	}
+
 	// If running with the `--csv` flag, configure things to ensure the output
 	// is correct (i.e. that it's just the csv).
 	if cmd.Config.CSV {
@@ -394,6 +401,29 @@ func (cmd *Command) setupConfig() error {
 	}
 
 	return nil
+}
+
+// applyPSet takes a pset string of the form `arg` or `arg=val` and applies it
+// as if the user had run `\pset arg val`. The only difference is that applying
+// pset here suppresses any output to stdout.
+func (cmd *Command) applyPSet(pset string) error {
+	// We expect arg to be one of the folowing formats:
+	// arg
+	// arg=val
+	args := strings.SplitN(pset, "=", 2)
+
+	// This is kind of hacky, but until we re-think the metaCommand interface to
+	// take a printer interface somewhere (so we can pass in the nopPrinter
+	// here), we're just going to discard stdout for the duration of this apply,
+	// and then set stdout back to its previous writer after the apply.
+	hold := cmd.stdout
+	cmd.stdout = io.Discard
+	defer func() {
+		cmd.stdout = hold
+	}()
+
+	_, err := newMetaPSet(args).execute(cmd)
+	return err
 }
 
 func (cmd *Command) executeAndWriteQuery(qry query) error {

--- a/cli/config.go
+++ b/cli/config.go
@@ -18,6 +18,9 @@ type Config struct {
 
 	// CSV (Comma-Separated Values) table output mode.
 	CSV bool `json:"csv"`
+
+	// PSet takes one or more pset arguments of the form: `--pset=VAR[=ARG]`.
+	PSets []string `json:"pset"`
 }
 
 type CloudAuthConfig struct {

--- a/cli/config.go
+++ b/cli/config.go
@@ -15,6 +15,9 @@ type Config struct {
 	KafkaConfig string `json:"kafka-config"`
 
 	HistoryPath string `json:"history-path"`
+
+	// CSV (Comma-Separated Values) table output mode.
+	CSV bool `json:"csv"`
 }
 
 type CloudAuthConfig struct {

--- a/cmd/fbsql/main.go
+++ b/cmd/fbsql/main.go
@@ -60,5 +60,7 @@ func buildFlags(cmd *cobra.Command, cliCmd *cli.Command) {
 
 	flags.StringVar(&cliCmd.Config.KafkaConfig, "kafka-config", cliCmd.Config.KafkaConfig, "Kafka configuration file to read from.")
 
+	flags.BoolVar(&cliCmd.Config.CSV, "csv", cliCmd.Config.CSV, "CSV (Comma-Separated Values) table output mode.")
+
 	flags.String("config", "", "Configuration file to read from.")
 }

--- a/cmd/fbsql/main.go
+++ b/cmd/fbsql/main.go
@@ -59,8 +59,8 @@ func buildFlags(cmd *cobra.Command, cliCmd *cli.Command) {
 	flags.StringVar(&cliCmd.Config.CloudAuth.Password, "password", cliCmd.Config.CloudAuth.Password, "Password for FeatureBase Cloud access.")
 
 	flags.StringVar(&cliCmd.Config.KafkaConfig, "kafka-config", cliCmd.Config.KafkaConfig, "Kafka configuration file to read from.")
-
 	flags.BoolVar(&cliCmd.Config.CSV, "csv", cliCmd.Config.CSV, "CSV (Comma-Separated Values) table output mode.")
+	flags.StringSliceVar(&cliCmd.Config.PSets, "pset", cliCmd.Config.PSets, "Set printing option VAR to ARG (see \\pset command). Use form: --pset=VAR[=ARG]")
 
 	flags.String("config", "", "Configuration file to read from.")
 }


### PR DESCRIPTION
`--csv` will run in non-interactive mode with csv output
`--pset=VAR[=ARG]` will apply a pset as if you had run `\pset var arg`

```
➜  travis/cli/config fbsql --config dax.toml --pset tuples_only=on --csv -c "select * from users"
1,Anne,38
2,Bill,23
3,Cindy,64
```

@tgruben I think I've addressed the issues you mentioned around csv output, but if not let me know.

There's one little hacky thing I did in this PR to suppress stdout when using the `--pset` flag. I want to rethink that, but this solution works until I come up with something more elegant. I'm basically gonna wait until I run into the next problem that forces me to address it.