### PR TITLE
Add tests cases for coverage in expressiontypes.go

### DIFF
--- a/dax/test/dax/dax_test.go
+++ b/dax/test/dax/dax_test.go
@@ -149,7 +149,8 @@ func TestDAXIntegration(t *testing.T) {
 			"viewtests/drop-view", // drop view does a delete
 			"viewtests/drop-view-if-exists-after-drop",
 			"viewtests/select-view-after-drop",
-			"time_quantum_insert/test-12", // orchestrator currently does not support to,from args on Rows()
+			"time_quantum_insert/stringset-rangeq", // orchestrator currently does not support to,from args on Rows()
+			"time_quantum_insert/idset-rangeq",
 		}
 
 		doSkip := func(name string) bool {

--- a/sql3/planner/expression.go
+++ b/sql3/planner/expression.go
@@ -1720,7 +1720,7 @@ func (n *qualifiedRefPlanExpression) Evaluate(currentRow []interface{}) (interfa
 	}
 
 	switch n.dataType.(type) {
-	case *parser.DataTypeIDSet:
+	case *parser.DataTypeIDSet, *parser.DataTypeIDSetQuantum:
 		row, ok := currentRow[n.columnIndex].([]uint64)
 		if !ok {
 			return nil, sql3.NewErrInternalf("unexpected type for current row '%T'", currentRow[n.columnIndex])

--- a/sql3/planner/inbuiltfunctionsset.go
+++ b/sql3/planner/inbuiltfunctionsset.go
@@ -49,7 +49,7 @@ func (n *callPlanExpression) EvaluateSetContains(currentRow []interface{}) (inte
 				return nil, sql3.NewErrInternalf("unable to convert value")
 			}
 
-			return intSetContains(targetSet, int64(testValue)), nil
+			return intSetContains(targetSet, testValue), nil
 
 		default:
 			return nil, sql3.NewErrInternalf("unexpected data type '%T'", typ)

--- a/sql3/test/defs/defs.go
+++ b/sql3/test/defs/defs.go
@@ -45,6 +45,7 @@ var TableTests []TableTest = []TableTest{
 	setLiteralTests,
 	setFunctionTests,
 	setParameterTests,
+	setTimeQuantumTests,
 	dateTimePartTests,
 	dateTimeNameTests,
 	toTimestampTests,

--- a/sql3/test/defs/defs_timequantum.go
+++ b/sql3/test/defs/defs_timequantum.go
@@ -28,6 +28,48 @@ var timeQuantumTest = TableTest{
 		},
 		{
 			SQLs: sqls(
+				"insert into time_quantum_insert (_id, i1, ss1, ids1) values (1, 1, ['1'], {[1]})",
+			),
+			ExpErr: "an expression of type 'tuple(idset)' cannot be assigned to type 'idsetq'",
+		},
+		{
+			SQLs: sqls(
+				"insert into time_quantum_insert (_id, i1, ss1, ids1) values (1, 1, {'notatimestamp', ['1']}, [1])",
+			),
+			ExpErr: "unable to convert 'notatimestamp' to type 'timestamp'",
+		},
+		{
+			SQLs: sqls(
+				"insert into time_quantum_insert (_id, i1, ss1, ids1) values (1, 1, ['1'], {'notatimestamp', [1]})",
+			),
+			ExpErr: "unable to convert 'notatimestamp' to type 'timestamp'",
+		},
+		{
+			SQLs: sqls(
+				"insert into time_quantum_insert (_id, i1, ss1, ids1) values (1, 1, {'2022-01-01T00:00:00Z', [1]}, {[1]})",
+			),
+			ExpErr: "an expression of type 'tuple(string, idset)' cannot be assigned to type 'stringsetq'",
+		},
+		{
+			SQLs: sqls(
+				"insert into time_quantum_insert (_id, i1, ss1, ids1) values (1, 1, ['1'], {'2022-01-01T00:00:00Z', ['1']})",
+			),
+			ExpErr: "an expression of type 'tuple(string, stringset)' cannot be assigned to type 'idsetq'",
+		},
+		{
+			SQLs: sqls(
+				"insert into time_quantum_insert (_id, i1, ss1, ids1) values (1, 1, '1', {[1]})",
+			),
+			ExpErr: "an expression of type 'string' cannot be assigned to type 'stringsetq'",
+		},
+		{
+			SQLs: sqls(
+				"insert into time_quantum_insert (_id, i1, ss1, ids1) values (1, 1, ['1'], 1)",
+			),
+			ExpErr: "an expression of type 'int' cannot be assigned to type 'idsetq'",
+		},
+		{
+			SQLs: sqls(
 				"insert into time_quantum_insert (_id, i1, ss1, ids1) values (1, 1, {1676649734, ['1']}, {1676649734, [1]})",
 			),
 			ExpHdrs: hdrs(),
@@ -84,7 +126,7 @@ var timeQuantumTest = TableTest{
 			SQLs: sqls(
 				"select a._id, a.ss1 from time_quantum_insert a where rangeq(a.ss1, null, null)",
 			),
-			ExpErr: "alling ranqeq() 'from' and 'to' parameters cannot both be null",
+			ExpErr: "calling ranqeq() 'from' and 'to' parameters cannot both be null",
 		},
 		{
 			SQLs: sqls(
@@ -99,6 +141,7 @@ var timeQuantumTest = TableTest{
 			ExpErr: "calling ranqeq() usage invalid",
 		},
 		{
+			name: "stringset-rangeq",
 			SQLs: sqls(
 				"select a._id, a.ss1 from time_quantum_insert a where rangeq(a.ss1, '2022-01-02T00:00:00Z', null)",
 			),
@@ -108,6 +151,20 @@ var timeQuantumTest = TableTest{
 			),
 			ExpRows: rows(
 				row(int64(1), []string{"1", "test1", "test2"}),
+			),
+			Compare: CompareExactUnordered,
+		},
+		{
+			name: "idset-rangeq",
+			SQLs: sqls(
+				"select a._id, a.ids1 from time_quantum_insert a where rangeq(a.ids1, '2022-01-02T00:00:00Z', null)",
+			),
+			ExpHdrs: hdrs(
+				hdr("_id", fldTypeID),
+				hdr("ids1", fldTypeIDSetQ),
+			),
+			ExpRows: rows(
+				row(int64(1), []int64{1, 2}),
 			),
 			Compare: CompareExactUnordered,
 		},


### PR DESCRIPTION
FB-2041
Added tests for typeIsTimeQuantum and typeIsSet and made them pass. 
Added tests for DataTypeTuple cases in typesAreAssignmentCompatible. 
Timestamp conversion checking is handled before it gets to that point but I left those branches in as a backstop.
Checking to see if DataType[String,ID]SetQuantum can be assigned to themselves doesn't appear to be reachable currently but left those branches in, because something may use them in future.