### PR TITLE
make IDK check featurebase version

### DIFF
--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -353,7 +353,7 @@ run go tests idk race:
     - cd ./idk/
     - echo $PROJECT
     - echo $CI_COMMIT_REF_SLUG
-    - BRANCH_NAME=${CI_COMMIT_REF_SLUG} make test-all-race
+    - BRANCH_NAME=${CI_COMMIT_REF_SLUG} IDK_FEATUREBASE_HASH=${CI_COMMIT_SHA} make test-all-race
   after_script:
     - cd ./idk/
     - make save-pilosa-logs
@@ -378,7 +378,7 @@ run go tests idk shard transactional:
     - cd ./idk/
     - echo $PROJECT
     - echo $CI_COMMIT_REF_SLUG
-    - BRANCH_NAME=${CI_COMMIT_REF_SLUG} make test-all
+    - BRANCH_NAME=${CI_COMMIT_REF_SLUG} IDK_FEATUREBASE_HASH=${CI_COMMIT_SHA} make test-all
   after_script:
     - cd ./idk/
     - make save-pilosa-logs
@@ -404,7 +404,7 @@ run go tests idk 533:
     - cd ./idk/
     - echo $PROJECT
     - echo $CI_COMMIT_REF_SLUG
-    - CONFLUENT_VERSION=5.3.3 BRANCH_NAME=${CI_COMMIT_REF_SLUG} make test-all
+    - CONFLUENT_VERSION=5.3.3 BRANCH_NAME=${CI_COMMIT_REF_SLUG} IDK_FEATUREBASE_HASH=${CI_COMMIT_SHA} make test-all
   after_script:
     - cd ./idk/
     - make save-pilosa-logs
@@ -428,7 +428,7 @@ run go tests idk sasl:
     - cd ./idk/
     - echo $PROJECT
     - echo $CI_COMMIT_REF_SLUG
-    - BRANCH_NAME=${CI_COMMIT_REF_SLUG} make test-all-kafka-sasl
+    - BRANCH_NAME=${CI_COMMIT_REF_SLUG} IDK_FEATUREBASE_HASH=${CI_COMMIT_SHA} make test-all-kafka-sasl
   after_script:
     - cd ./idk/
     - make save-pilosa-logs

--- a/idk/Makefile
+++ b/idk/Makefile
@@ -158,9 +158,9 @@ start-all: testenv build-wait
 	$(DOCKER_COMPOSE) up -d postgres
 	$(DOCKER_COMPOSE) run -T  wait postgres pg_isready -h postgres -p 5432 -U postgres
 	$(DOCKER_COMPOSE) up -d dax
-	BRANCH_NAME=${BRANCH_NAME} $(DOCKER_COMPOSE) up -d pilosa
-	BRANCH_NAME=${BRANCH_NAME} $(DOCKER_COMPOSE) up -d pilosa-tls
-	BRANCH_NAME=${BRANCH_NAME} $(DOCKER_COMPOSE) up -d pilosa-auth
+	BRANCH_NAME=${BRANCH_NAME} $(DOCKER_COMPOSE) up -d --build pilosa
+	BRANCH_NAME=${BRANCH_NAME} $(DOCKER_COMPOSE) up -d --build pilosa-tls
+	BRANCH_NAME=${BRANCH_NAME} $(DOCKER_COMPOSE) up -d --build pilosa-auth
 	$(DOCKER_COMPOSE) run -T  wait pilosa curl --silent --fail http://pilosa:10101/status
 	$(DOCKER_COMPOSE) run -T  wait pilosa-tls curl --silent --cacert /certs/ca.crt --key /certs/theclient.key --cert /certs/theclient.crt --fail https://pilosa-tls:10111/status
 	$(DOCKER_COMPOSE) run -T  wait pilosa-auth curl --silent --fail http://pilosa-auth:10105/version

--- a/idk/docker-compose.yml
+++ b/idk/docker-compose.yml
@@ -120,6 +120,7 @@ services:
       dockerfile: ./idk/Dockerfile-test
     environment:
       IDK_DEFAULT_SHARD_TRANSACTIONAL: ${IDK_DEFAULT_SHARD_TRANSACTIONAL}
+      IDK_FEATUREBASE_HASH: ${IDK_FEATUREBASE_HASH}
     volumes:
       - ./testenv/certs:/certs
       - ./docker-sasl/ssl_keys:/ssl_keys


### PR DESCRIPTION
After a weird CI failure that suddenly went away, I have theorized that we're getting cached versions of the featurebase docker image in CI when we don't intend to, and thus, running IDK tests against *the wrong version of featurebase*. This checks for that problem.