### PR TITLE
handle tag-only commits with no hash in version

### DIFF
--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -353,7 +353,7 @@ run go tests idk race:
     - cd ./idk/
     - echo $PROJECT
     - echo $CI_COMMIT_REF_SLUG
-    - BRANCH_NAME=${CI_COMMIT_REF_SLUG} IDK_FEATUREBASE_HASH=${CI_COMMIT_SHA} make test-all-race
+    - BRANCH_NAME=${CI_COMMIT_REF_SLUG} IDK_FEATUREBASE_TAG=${CI_COMMIT_TAG} IDK_FEATUREBASE_HASH=${CI_COMMIT_SHA} make test-all-race
   after_script:
     - cd ./idk/
     - make save-pilosa-logs
@@ -378,7 +378,7 @@ run go tests idk shard transactional:
     - cd ./idk/
     - echo $PROJECT
     - echo $CI_COMMIT_REF_SLUG
-    - BRANCH_NAME=${CI_COMMIT_REF_SLUG} IDK_FEATUREBASE_HASH=${CI_COMMIT_SHA} make test-all
+    - BRANCH_NAME=${CI_COMMIT_REF_SLUG} IDK_FEATUREBASE_TAG=${CI_COMMIT_TAG} IDK_FEATUREBASE_HASH=${CI_COMMIT_SHA} make test-all
   after_script:
     - cd ./idk/
     - make save-pilosa-logs
@@ -404,7 +404,7 @@ run go tests idk 533:
     - cd ./idk/
     - echo $PROJECT
     - echo $CI_COMMIT_REF_SLUG
-    - CONFLUENT_VERSION=5.3.3 BRANCH_NAME=${CI_COMMIT_REF_SLUG} IDK_FEATUREBASE_HASH=${CI_COMMIT_SHA} make test-all
+    - CONFLUENT_VERSION=5.3.3 BRANCH_NAME=${CI_COMMIT_REF_SLUG} IDK_FEATUREBASE_TAG=${CI_COMMIT_TAG} IDK_FEATUREBASE_HASH=${CI_COMMIT_SHA} make test-all
   after_script:
     - cd ./idk/
     - make save-pilosa-logs
@@ -428,7 +428,7 @@ run go tests idk sasl:
     - cd ./idk/
     - echo $PROJECT
     - echo $CI_COMMIT_REF_SLUG
-    - BRANCH_NAME=${CI_COMMIT_REF_SLUG} IDK_FEATUREBASE_HASH=${CI_COMMIT_SHA} make test-all-kafka-sasl
+    - BRANCH_NAME=${CI_COMMIT_REF_SLUG} IDK_FEATUREBASE_TAG=${CI_COMMIT_TAG} IDK_FEATUREBASE_HASH=${CI_COMMIT_SHA} make test-all-kafka-sasl
   after_script:
     - cd ./idk/
     - make save-pilosa-logs

--- a/idk/docker-compose.yml
+++ b/idk/docker-compose.yml
@@ -121,6 +121,7 @@ services:
     environment:
       IDK_DEFAULT_SHARD_TRANSACTIONAL: ${IDK_DEFAULT_SHARD_TRANSACTIONAL}
       IDK_FEATUREBASE_HASH: ${IDK_FEATUREBASE_HASH}
+      IDK_FEATUREBASE_TAG: ${IDK_FEATUREBASE_TAG}
     volumes:
       - ./testenv/certs:/certs
       - ./docker-sasl/ssl_keys:/ssl_keys

--- a/idk/ingest_test.go
+++ b/idk/ingest_test.go
@@ -89,6 +89,19 @@ func TestFeaturebaseVersion(t *testing.T) {
 		t.Fatalf("unmarshalling version: %v", err)
 	}
 	v := vh.Version
+	expectedTag := os.Getenv("IDK_FEATUREBASE_TAG")
+	if expectedTag != "" {
+		// if a tag is set, we're in a tagged pipeline, and the version
+		// should just be vX.Y or something similar, without a commit
+		// hash.
+		if v != expectedTag {
+			t.Fatalf("version %s does not match expected tag %s", v, expectedTag)
+		}
+		t.Logf("featurebase version %q matches expectations", expectedTag)
+		return
+	}
+	// no tag. we expect to always have a hash, and if there's a specific
+	// expected hash, we verify it.
 	expectedHash := os.Getenv("IDK_FEATUREBASE_HASH")
 	if expectedHash == "" {
 		t.Skipf("featurebase version: %s [no expected version]", v)


### PR DESCRIPTION
When doing the release process, we generate version numbers that have a version tag but don't have a hash. The IDK test against the expected hash doesn't work in this context. Let's check for an expected tag first.