### PR TITLE
off-by-v error in spelling of versions

### DIFF
--- a/idk/ingest_test.go
+++ b/idk/ingest_test.go
@@ -93,8 +93,10 @@ func TestFeaturebaseVersion(t *testing.T) {
 	if expectedTag != "" {
 		// if a tag is set, we're in a tagged pipeline, and the version
 		// should just be vX.Y or something similar, without a commit
-		// hash.
-		if v != expectedTag {
+		// hash. in that case, the tag passed to us from the environment
+		// will look like vX.Y, but the version reported by the version
+		// endpoint is just X.Y. Argh.
+		if v != expectedTag && ("v"+v) != expectedTag {
 			t.Fatalf("version %s does not match expected tag %s", v, expectedTag)
 		}
 		t.Logf("featurebase version %q matches expectations", expectedTag)


### PR DESCRIPTION
oh for crying out loud.