### PR TITLE
don't panic on a MIN that isn't a call

### DIFF
--- a/sql3/parser/parser.go
+++ b/sql3/parser/parser.go
@@ -2742,8 +2742,12 @@ func (p *Parser) parseOperand() (expr Expr, err error) {
 	case VARIABLE:
 		return &Variable{Name: lit, NamePos: pos}, nil
 	case MIN, MAX:
-		ident := &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT}
-		return p.parseCall(ident)
+		pk := p.peek()
+		if pk == LP {
+			ident := &Ident{Name: lit, NamePos: pos, Quoted: false}
+			return p.parseCall(ident)
+		}
+		return nil, p.errorExpected(p.pos, pk, "call expression")
 	case STRING:
 		return &StringLit{ValuePos: pos, Value: lit}, nil
 	case FLOAT:

--- a/sql3/parser/parser_test.go
+++ b/sql3/parser/parser_test.go
@@ -40,6 +40,9 @@ func TestParser_ParseMinMaxColumnConstraints(t *testing.T) {
 		t.Run("ErrNoKey", func(t *testing.T) {
 			AssertParseStatementError(t, `CREATE TABLE tbl (col1 INT MIN`, `1:30: expected expression, found 'EOF'`)
 		})
+		t.Run("ErrNoCall", func(t *testing.T) {
+			AssertParseStatementError(t, `SELECT MIN;`, `1:11: expected call expression, found ';'`)
+		})
 		t.Run("Simple", func(t *testing.T) {
 			AssertParseStatement(t, `CREATE TABLE tbl (col1 INT MIN 0)`, &parser.CreateTableStatement{
 				Create: pos(0),

--- a/sql3/planner/opaltertable.go
+++ b/sql3/planner/opaltertable.go
@@ -94,11 +94,11 @@ func (i *alterTableRowIter) Next(ctx context.Context) (types.Row, error) {
 		fos := i.columnDef.fos
 
 		fld, err := pilosa.FieldFromFieldOptions(fname, fos...)
-		// all newly created fields unconditionally have TrackExistence turned on.
-		fld.Options.TrackExistence = true
 		if err != nil {
 			return nil, err
 		}
+		// all newly created fields unconditionally have TrackExistence turned on.
+		fld.Options.TrackExistence = true
 
 		if err := i.planner.schemaAPI.CreateField(ctx, tname, fld); err != nil {
 			return nil, err

--- a/sql3/planner/opcreatetable.go
+++ b/sql3/planner/opcreatetable.go
@@ -112,11 +112,11 @@ func (i *createTableRowIter) Next(ctx context.Context) (types.Row, error) {
 
 	for _, f := range i.columns {
 		fld, err := pilosa.FieldFromFieldOptions(dax.FieldName(f.name), f.fos...)
-		// We unconditionally turn on TrackExistence for all newly-created fields.
-		fld.Options.TrackExistence = true
 		if err != nil {
 			return nil, errors.Wrapf(err, "creating field from field options: %s", f.name)
 		}
+		// We unconditionally turn on TrackExistence for all newly-created fields.
+		fld.Options.TrackExistence = true
 		fields = append(fields, fld)
 	}
 

--- a/sql3/test/defs/defs_create_table.go
+++ b/sql3/test/defs/defs_create_table.go
@@ -32,6 +32,13 @@ var createTable = TableTest{
 			ExpErr: "expected literal, found bad",
 		},
 		{
+			name: "minAboveMax",
+			SQLs: sqls(
+				"create table bar (_id id, i1 int min 20 max 19)",
+			),
+			ExpErr: "int field min cannot be greater than max",
+		},
+		{
 			name: "commentString",
 			SQLs: sqls(
 				"create table bar (_id id, i1 int) comment 'this should work'",


### PR DESCRIPTION
parseOperand was assuming that any reference to MIN in a place where an operand was expected was a call, which it should be, but it might not be. parseCallExpression panics if it doesn't find a parenthesis, because it's never supposed to be called when we don't know we have one.

The test for this is in with MinMaxColumnConstraints, even though it's actually a test of MinMaxFunctionCalls, because that's where the other tests involving the special MIN/MAX tokens live.