### PR TITLE
uncomment old LIMIT tests, make them pass

### DIFF
--- a/sql3/parser/ast.go
+++ b/sql3/parser/ast.go
@@ -4037,7 +4037,7 @@ func (s *SelectStatement) String() string {
 	}
 
 	if s.Limit.IsValid() {
-		fmt.Fprintf(&buf, "LIMIT %s", s.LimitExpr.String())
+		fmt.Fprintf(&buf, " LIMIT %s", s.LimitExpr.String())
 	}
 
 	return buf.String()


### PR DESCRIPTION
We forward-ported a handful of tests from the previous parser which relied on LIMIT clauses, but then we didn't support that. Now that we do, we uncomment most of these tests, and actually give them the correct data structures to compare with.

We leave two tests commented out. One was using `limit 10, 5` to express a limit plus offset, and the other is using `not fld = 1` as a WHERE clause, but we don't support unary-not to negate other expressions.

In the process, we discover that converting a SELECT with a LIMIT clause back to a string has a missing space, and fix that.