### PR TITLE
Add test coverage to expressionanalyzer.go

### DIFF
--- a/sql3/planner/expressionanalyzer.go
+++ b/sql3/planner/expressionanalyzer.go
@@ -632,7 +632,7 @@ func (p *ExecutionPlanner) analyzeBinaryExpression(ctx context.Context, expr *pa
 			if ok {
 				//we have a select in the expression list so make sure it is the only thing in the expression list
 				if len(lst.Exprs) > 1 {
-					return nil, sql3.NewErrInternalf("expresion list should only contain one select statement")
+					return nil, sql3.NewErrInternalf("expression list should only contain one select statement")
 				}
 				//make sure select only returns one column
 				if len(sel.Columns) > 1 {

--- a/sql3/test/defs/defs_delete.go
+++ b/sql3/test/defs/defs_delete.go
@@ -118,6 +118,30 @@ var deleteTests = TableTest{
 			ExpRows: rows(),
 			Compare: CompareExactUnordered,
 		},
+		// inner joins in delete are apparently not supported yet
+		// when they are, this will fill in test coverage for expressionanalyzer.go
+		/*
+			{
+				SQLs: sqls(
+					"delete from del_all_types a1 inner join del_all_types a2 on a1._id=a2._id where a1._id in (select _id from del_all_types);",
+				),
+				ExpHdrs: hdrs(
+					hdr("_id", fldTypeID),
+				),
+				ExpRows: rows(),
+				Compare: CompareExactUnordered,
+			},
+			{
+				SQLs: sqls(
+					"select _id from del_all_types;",
+				),
+				ExpHdrs: hdrs(
+					hdr("_id", fldTypeID),
+				),
+				ExpRows: rows(),
+				Compare: CompareExactUnordered,
+			},
+		*/
 
 		// dates
 		{

--- a/sql3/test/defs/defs_in.go
+++ b/sql3/test/defs/defs_in.go
@@ -128,6 +128,51 @@ var inTests = TableTest{
 			),
 			Compare: CompareExactUnordered,
 		},
+		{
+			SQLs: sqls(
+				"select t1._id in (select t2._id from in_all_types as t2) from in_all_types as t1",
+			),
+			ExpHdrs: hdrs(
+				hdr("", fldTypeBool),
+			),
+			ExpRows: rows(
+				row(bool(true)),
+			),
+			Compare: CompareExactUnordered,
+		},
+		// This test fails - re-enable it when fixing the bug
+		/*
+			{
+				SQLs: sqls(
+					"select t1._id in (select t2.id1 from in_all_types as t2) from in_all_types as t1",
+				),
+				ExpHdrs: hdrs(
+					hdr("", fldTypeBool),
+				),
+				ExpRows: rows(
+					row(bool(false)),
+				),
+				Compare: CompareExactUnordered,
+			},
+		*/
+		// This test also fails.
+		// Once re-enabled and passing, it provides coverage for expressionanalyzer.go
+		// (*ExecutionPlanner).analyzeBinaryExpression in the case where the left hand side
+		// of the IN contains a JOIN.
+		/*
+			{
+				SQLs: sqls(
+					"select a1._id from in_all_types a1 inner join in_all_types a2 on a1._id=a2._id where a1._id in (select _id from in_all_types);",
+				),
+				ExpHdrs: hdrs(
+					hdr("", fldTypeBool),
+				),
+				ExpRows: rows(
+					row(bool(true)),
+				),
+				Compare: CompareExactUnordered,
+			},
+		*/
 	},
 }
 
@@ -259,5 +304,63 @@ var notInTests = TableTest{
 			),
 			Compare: CompareExactUnordered,
 		},
+		// this test currently causes a panic
+		/*
+			{
+				SQLs: sqls(
+					"select t1._id in (select t2.s1 from in_all_types as t2) from in_all_types as t1",
+				),
+				ExpHdrs: hdrs(
+					hdr("", fldTypeBool),
+				),
+				ExpErr:  "types 'id' and 'string' are not equatable",
+				Compare: CompareExactUnordered,
+			},
+		*/
+		{
+			SQLs: sqls(
+				"select t1._id not in (select t2._id from in_all_types as t2) from in_all_types as t1",
+			),
+			ExpHdrs: hdrs(
+				hdr("", fldTypeBool),
+			),
+			ExpRows: rows(
+				row(bool(false)),
+			),
+			Compare: CompareExactUnordered,
+		},
+		// This test fails - re-enable it when the bug is fixed
+		/*
+			{
+				SQLs: sqls(
+					"select t1._id not in (select t2.id1 from in_all_types as t2) from in_all_types as t1",
+				),
+				ExpHdrs: hdrs(
+					hdr("", fldTypeBool),
+				),
+				ExpRows: rows(
+					row(bool(true)),
+				),
+				Compare: CompareExactUnordered,
+			},
+		*/
+		// This test also fails.
+		// Once re-enabled and passing, it provides coverage for expressionanalyzer.go
+		// (*ExecutionPlanner).analyzeBinaryExpression in the case where the left hand side
+		// of the IN contains a JOIN.
+		/*
+			{
+				SQLs: sqls(
+					"select a1._id from in_all_types a1 inner join in_all_types a2 on a1._id=a2._id where a1._id not in (select _id from in_all_types);",
+				),
+				ExpHdrs: hdrs(
+					hdr("", fldTypeBool),
+				),
+				ExpRows: rows(
+					row(bool(true)),
+				),
+				Compare: CompareExactUnordered,
+			},
+		*/
 	},
 }


### PR DESCRIPTION
analyzeExpression - tupleLiteralExpression was covered by something else between the ticket getting filed and me starting on it. (*ExecutionPlanner).analyzeBinaryExpression now has increased coverage for IN / NOT IN. Several bugs got revealed by adding tests; those tests are commented out but can be re-enabled by whoever ends up working on the bugs. Tickets are filed.