### PR TITLE
fb-2026 : added test cases with cache type & size for copy

### DIFF
--- a/sql3/test/defs/defs.go
+++ b/sql3/test/defs/defs.go
@@ -203,6 +203,8 @@ var TableTests []TableTest = []TableTest{
 	// copy
 	copyTable,
 	copyTests,
+	copyTableCache,
+	copyTestsCache,
 
 	// bool (batch logic)
 	boolTests,

--- a/sql3/test/defs/defs_copy.go
+++ b/sql3/test/defs/defs_copy.go
@@ -27,7 +27,30 @@ var copyTable = TableTest{
 	),
 	SQLTests: nil,
 }
-
+var copyTableCache = TableTest{
+	name: "copyTableCache",
+	Table: tbl(
+		"copytestcache",
+		srcHdrs(
+			srcHdr("_id", fldTypeID),
+			srcHdr("id_col", fldTypeID, "CACHETYPE LRU", "SIZE 1024"),
+			srcHdr("string_col", fldTypeString, "CACHETYPE RANKED", "SIZE 1024"),
+			srcHdr("int_col", fldTypeInt),
+			srcHdr("decimal_col", fldTypeDecimal2),
+			srcHdr("bool_col", fldTypeBool),
+			srcHdr("time_col", fldTypeTimestamp),
+			srcHdr("stringset_col", fldTypeStringSet, "CACHETYPE RANKED", "SIZE 1024"),
+			srcHdr("idset_col", fldTypeIDSet, "CACHETYPE LRU", "SIZE 1024"),
+		),
+		srcRows(
+			srcRow(int64(1), int64(10), string("foo"), int64(10), float64(10), bool(false), knownTimestamp(), []string{"foo", "bar"}, []int64{1, 2}),
+			srcRow(int64(2), int64(11), string("foo1"), int64(11), float64(11), bool(true), knownTimestamp(), []string{"foo1", "bar1"}, []int64{11, 21}),
+			srcRow(int64(3), int64(12), string("foo2"), int64(12), float64(12), bool(false), knownTimestamp(), []string{"foo2", "bar2"}, []int64{12, 22}),
+			srcRow(int64(4), int64(13), string("foo3"), int64(13), float64(13), bool(true), knownTimestamp(), []string{"foo3", "bar3"}, []int64{13, 23}),
+		),
+	),
+	SQLTests: nil,
+}
 var copyTests = TableTest{
 	name: "copyTests",
 	SQLTests: []SQLTest{
@@ -49,6 +72,27 @@ var copyTests = TableTest{
 			name: "copy-table-to-table",
 			SQLs: sqls(
 				`copy copytest to copytesttwo;`,
+			),
+			ExpHdrs: hdrs(),
+			ExpRows: rows(),
+			Compare: CompareExactOrdered,
+		},
+	},
+}
+var copyTestsCache = TableTest{
+	name: "copyTestsCache",
+	SQLTests: []SQLTest{
+		{
+			name: "copy-table-to-table-same-name",
+			SQLs: sqls(
+				`copy copytestcache to copytestcache;`,
+			),
+			ExpErr: "already exists",
+		},
+		{
+			name: "copy-table-to-table",
+			SQLs: sqls(
+				`copy copytestcache to copytestcachetwo;`,
 			),
 			ExpHdrs: hdrs(),
 			ExpRows: rows(),


### PR DESCRIPTION
This PR caters to the test cases added for testing `copy` with cache type & cache size different than the default Pilosa Cache type & size for fld type - `fldTypeID, fldTypeIDSet, fldTypeString, fldTypeStringSet`